### PR TITLE
Fix both light and dark images from appearing in light mode (attempt #1)

### DIFF
--- a/blog/stylesheets/extra.css
+++ b/blog/stylesheets/extra.css
@@ -23,3 +23,8 @@
   -webkit-mask-image: var(--md-admonition-icon--update);
           mask-image: var(--md-admonition-icon--update);
 }
+
+[data-md-color-scheme="custom-light"] img[src$="#only-dark"]
+[data-md-color-scheme="custom-light"] img[src$="#gh-dark-mode-only"] {
+  display: none; /* Hide dark images in light mode */
+}


### PR DESCRIPTION
## Related issue

**If applicable, please provide a link to the issue related to this change.**

- [x] **Related issue:** https://github.com/josh-wong/josh-wong.github.io/issues/10
- [ ] **No related issue**

## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

This PR fixes a bug introduced in a recent update to Material for MkDocs. The fix adds a style for a custom color scheme to remove dark images from appearing below the light image when in light mode.

> **Note**
>
> When in dark mode, only one image appears as expected.

The fix for this follows the guidance from the following discussion in the Material for MkDocs repository:

- https://github.com/squidfunk/mkdocs-material/discussions/5596#discussioncomment-6133721

### Type of change

- [ ] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [x] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Implemented the fix as mentioned in https://github.com/squidfunk/mkdocs-material/discussions/5596#discussioncomment-6133721. Then, ran the site locally to confirm only one image appeared as expected in both light and dark modes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
