### PR TITLE
Fix both light and dark images from appearing in light mode (attempt #3)

### DIFF
--- a/blog/stylesheets/extra.css
+++ b/blog/stylesheets/extra.css
@@ -24,12 +24,12 @@
           mask-image: var(--md-admonition-icon--update);
 }
 
-[data-md-color-scheme="slate"] img[src$="#only-dark"]
-[data-md-color-scheme="slate"] img[src$="#gh-dark-mode-only"] {
+[data-md-color-scheme="dark"] img[src$="#only-dark"]
+[data-md-color-scheme="dark"] img[src$="#gh-dark-mode-only"] {
   display: none; /* Hide dark images in light mode */
 }
 
-[data-md-color-scheme="slate"] img[src$="#only-light"],
-[data-md-color-scheme="slate"] img[src$="#gh-light-mode-only"] {
+[data-md-color-scheme="light"] img[src$="#only-light"],
+[data-md-color-scheme="light"] img[src$="#gh-light-mode-only"] {
   display: none; /* Hide light images in dark mode */
 }


### PR DESCRIPTION
## Related issue

**If applicable, please provide a link to the issue related to this change.**

- [x] **Related issue:** https://github.com/josh-wong/josh-wong.github.io/issues/10
- [ ] **No related issue**

## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

> **Note**
>
> Previous attempts at fixing this issue are available in PRs https://github.com/josh-wong/josh-wong.github.io/pull/8 and https://github.com/josh-wong/josh-wong.github.io/pull/9. Although the issue appears fixed locally, the published site still shows both light and dark mode images when in light mode.

This PR attempts to fix a bug introduced in a recent update to Material for MkDocs. The fix changes the names of the color schemes to the name of the color schemes specified in `mkdocs.yml`.

The fix for this follows the guidance from the following discussion in the Material for MkDocs repository:

- https://github.com/squidfunk/mkdocs-material/discussions/5596#discussioncomment-6133721

### Type of change

- [ ] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [x] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Implemented the fix as mentioned in https://github.com/squidfunk/mkdocs-material/discussions/5596#discussioncomment-6133721. Then, ran the site locally to confirm only one image appeared as expected in both light and dark modes.

> **Note**
> 
> Although the issue seems fixed locally, I won't know if the issue is actually fixed until it is deployed. This seems to be a discrepancy between Material for MkDocs locally and when deployed. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
