### PR TITLE
Fix both light and dark images from appearing in light mode (attempt #6)

### DIFF
--- a/blog/stylesheets/extra.css
+++ b/blog/stylesheets/extra.css
@@ -2,10 +2,6 @@
   --md-primary-fg-color:        #080f53;
   --md-typeset-a-color:         #838fff;
 }
-[data-md-color-scheme="slate"] {
-  --md-primary-fg-color:        #080f53;
-  --md-typeset-a-color:         #838fff;
-}
 :root {
   --md-admonition-icon--update: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Free 6.1.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="M480 256c-17.67 0-32 14.31-32 32 0 52.94-43.06 96-96 96H192v-40c0-9.469-5.578-18.06-14.23-21.94-8.67-3.76-18.77-2.26-25.87 4.14l-80 72c-5.01 4.5-7.9 11-7.9 17.8s2.891 13.28 7.938 17.84l80 72C156.4 509.9 162.2 512 168 512c3.312 0 6.615-.688 9.756-2.062C186.4 506.1 192 497.5 192 488v-40h160c88.22 0 160-71.78 160-160 0-17.7-14.3-32-32-32zM160 128h159.1l.9 40c0 9.469 5.578 18.06 14.23 21.94 3.17 1.36 6.47 2.06 8.87 2.06 5.812 0 11.57-2.125 16.07-6.156l80-72C445.1 109.3 448 102.8 448 95.1s-2.891-13.28-7.938-17.84l-80-72c-7.047-6.312-17.19-7.875-25.83-4.094C325.6 5.938 319.1 14.53 319.1 24l.9 40H160C71.78 64 0 135.8 0 224c0 17.69 14.33 32 32 32s32-14.31 32-32c0-52.9 43.1-96 96-96z"/></svg>')
 }
@@ -22,14 +18,4 @@
   background-color: rgb(204, 222, 0);
   -webkit-mask-image: var(--md-admonition-icon--update);
           mask-image: var(--md-admonition-icon--update);
-}
-
-[data-md-color-scheme="light"] img[src$="#only-dark"],
-[data-md-color-scheme="light"] img[src$="#gh-dark-mode-only"] {
-  display: none; /* Hide dark images in light mode */
-}
-
-[data-md-color-scheme="dark"] img[src$="#only-light"],
-[data-md-color-scheme="dark"] img[src$="#gh-light-mode-only"] {
-  display: none; /* Hide light images in dark mode */
 }


### PR DESCRIPTION
## Related issue

**If applicable, please provide a link to the issue related to this change.**

- [x] **Related issue:** https://github.com/josh-wong/josh-wong.github.io/issues/10
- [ ] **No related issue**

## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

> **Note**
>
> Previous attempts at fixing this issue are available in PRs https://github.com/josh-wong/josh-wong.github.io/pull/8, https://github.com/josh-wong/josh-wong.github.io/pull/9, https://github.com/josh-wong/josh-wong.github.io/pull/11, https://github.com/josh-wong/josh-wong.github.io/pull/12, and https://github.com/josh-wong/josh-wong.github.io/pull/13. Although the issue appears fixed locally, the published site still shows both light and dark mode images when in light mode.

This PR attempts to fix a bug introduced in a recent update to Material for MkDocs. The fix removes the custom color scheme in `extra.css`.

The fix for this follows the guidance from the following discussion in the Material for MkDocs repository:

- https://github.com/squidfunk/mkdocs-material/discussions/5596#discussioncomment-6133721

### Type of change

- [ ] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [x] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Implemented the fix as mentioned in https://github.com/squidfunk/mkdocs-material/discussions/5596#discussioncomment-6133721. Then, ran the site locally to confirm only one image appeared as expected in both light and dark modes.

> **Note**
> 
> Although the issue seems fixed locally, I won't know if the issue is actually fixed until it is deployed. This seems to be a discrepancy between Material for MkDocs locally and when deployed. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
