### PR TITLE
fix: specify 'iCloud Drive'

### DIFF
--- a/blog/posts/2023-03-03-fixing-iphone-obsidian-sync-issue.md
+++ b/blog/posts/2023-03-03-fixing-iphone-obsidian-sync-issue.md
@@ -29,7 +29,7 @@ Anyway, on to fixing the issue!
 To get iCloud to sync your Obsidian vault again, perform the following steps from your iPhone:
 
 1. Confirm that you are connected to a Wi-Fi network.
-2. In the **Settings** app, disable **iCloud Drive**.
+2. In the **Settings** app, select **[your name]** and choose **iCloud**. Then, select **iCloud Drive** and disable **Sync this iPhone**.
 3. Restart your iPhone.
 4. In the **Settings** app, select **[your name]** and choose **iCloud**. Then, select **iCloud Drive** and enable **Sync this iPhone**. Wait for the contents in iCloud to sync.
 5. Open the **Files** app. If you do not see any folders in the Files app, make sure you are connected to Wi-Fi.

--- a/blog/posts/2023-03-03-fixing-iphone-obsidian-sync-issue.md
+++ b/blog/posts/2023-03-03-fixing-iphone-obsidian-sync-issue.md
@@ -31,7 +31,7 @@ To get iCloud to sync your Obsidian vault again, perform the following steps fro
 1. Confirm that you are connected to a Wi-Fi network.
 2. In the **Settings** app, disable **iCloud Drive**.
 3. Restart your iPhone.
-4. In the **Settings** app, enable **iCloud Drive**. Wait for the contents in iCloud to sync.
+4. In the **Settings** app, select **[your name]** and choose **iCloud**. Then, select **iCloud Drive** and enable **Sync this iPhone**. Wait for the contents in iCloud to sync.
 5. Open the **Files** app. If you do not see any folders in the Files app, make sure you are connected to Wi-Fi.
 6. Go to your **Obsidian** folder.
 7. Long-press the folder with the name of the Obsidian vault that you want to access, then select **Download Now**. Wait a while for the contents to download. Repeat this step for any other vaults that you want to access.

--- a/blog/posts/2023-03-03-fixing-iphone-obsidian-sync-issue.md
+++ b/blog/posts/2023-03-03-fixing-iphone-obsidian-sync-issue.md
@@ -29,9 +29,9 @@ Anyway, on to fixing the issue!
 To get iCloud to sync your Obsidian vault again, perform the following steps from your iPhone:
 
 1. Confirm that you are connected to a Wi-Fi network.
-2. In the **Settings** app, disable **iCloud**.
+2. In the **Settings** app, disable **iCloud Drive**.
 3. Restart your iPhone.
-4. In the **Settings** app, enable **iCloud**. Wait for the contents in iCloud to sync.
+4. In the **Settings** app, enable **iCloud Drive**. Wait for the contents in iCloud to sync.
 5. Open the **Files** app. If you do not see any folders in the Files app, make sure you are connected to Wi-Fi.
 6. Go to your **Obsidian** folder.
 7. Long-press the folder with the name of the Obsidian vault that you want to access, then select **Download Now**. Wait a while for the contents to download. Repeat this step for any other vaults that you want to access.


### PR DESCRIPTION
### Description
Hello! Thank you very much for this post! It solved the problem for me.

I don't know if you're open to PRs, but if you are then I wanted to suggest this small change. It's not 'iCloud' as a whole that needs disabling, but specifically 'iCloud Drive'. At first when I went into the Settings -> iCloud, I was expecting to see a single on/off switch for iCloud as a whole, but instead there are a bunch of individual things (e.g. Photos, iCloud Mail, iCloud Backup) that you enable or disable sync for. Hopefully this makes it a bit easier for future readers to figure out what's going on.

### Type of change

- [x] Documentation (new or updated documentation)