### PR TITLE
Add blog post for setting up Signal TLS proxy server

### DIFF
--- a/blog/posts/2024-01-08-setting-up-signal-proxy.md
+++ b/blog/posts/2024-01-08-setting-up-signal-proxy.md
@@ -1,0 +1,221 @@
+---
+date: 2024-01-08
+authors: [josh-wong]
+categories:
+  - Privacy
+tags:
+  - privacy
+  - security
+  - server 
+---
+
+# How to set up a Signal TLS proxy server
+
+This post describes how to set up a [Signal TLS proxy server](https://github.com/signalapp/Signal-TLS-Proxy) on a Linux-based operating system (OS). I was able to set up this proxy server on both Debian and Ubuntu.
+
+I wrote this post because the official Signal TLS proxy server repository lacks instructions for setting up a domain, which is necessary to run a proxy server. However, keep in mind that the steps to set up a proxy server may vary depending on your OS environment and domain name service provider.
+
+<!-- more -->
+
+## Why run a proxy server?
+
+Government officials are known to occasionally block access to apps in their countries, especially during times of social unrest and when they don't want information widely shared.
+
+By running a Signal proxy server, you can enable people in other countries to connect to Signal and stay in contact with friends and family.
+
+!!! warning "Attention"
+
+    For security reasons, you should avoid running a server of any type on your home network. If you decide to run a server on your home network, please understand that you're putting your network and at significant risk of being compromised.  
+
+## Set up your domain
+
+Before setting up your proxy server, you'll need to have a domain name so that others can connect to your proxy server from that domain name and modify the hostname of your OS.
+
+Configure a domain name in your domain name service provider account by setting up a DNS record (A record) to point the domain to your public IP address. For details on how to set up an A record, please check your domain name service provider's documentation. 
+
+!!! note
+
+    When setting up an A record, you should also be able to specify a subdomain. Specifying a subdomain will allow you to use your domain name for other purposes.
+
+After you've set up an A record in your domain name service provider account, you'll need to change the hostname of your OS. To do this, open **Terminal** and then open **/etc/hosts** by running the following command:
+
+```console
+sudo nano /etc/hosts
+```
+
+Below the default hostname, add the following line, replacing `<SUBDOMAIN>.<DOMAIN_NAME>.<TOP_LEVEL_DOMAIN>` with the address that you'll be using as your proxy server:
+
+```console
+192.168.1.101 <SUBDOMAIN>.<DOMAIN_NAME>.<TOP_LEVEL_DOMAIN>
+```
+
+!!! note
+
+    The local IP address shown above depends on your environment. Be sure to confirm what your local IP address is if you encounter issues.
+
+Save your changes, and close the file.
+
+## Set up DDNS and ddclient
+
+Next, you'll need to set up dynamic DNS (DDNS) to make sure that the IP address of your OS changes automatically. Without DDNS, you'd need to manually update the IP address in your domain name service provider account, which would require constant oversight.
+
+Most domain name service providers offer a DDNS service, which periodically checks for changes to an IP address and then automatically updates the DDNS database when a new IP address is discovered. For details on how to enable DDNS for your domain name, please check your domain name service provider's documentation.
+
+!!! note
+
+    After enabling DDNS in your domain name service account, you should receive a password. You'll need to enter that password later, so make note of it.
+
+After enabling DDNS for your domain name, you need to set up a DDNS client in your OS environment. In this tutorial, you will be installing ddclient. This client will automatically send updates to your domain name service provider when your IP address changes.
+
+To install **ddclient**, open **Terminal** and run the following command:
+
+```console
+sudo apt-get install ddclient
+```
+
+During setup, a wizard will be displayed. When prompted, enter the following configurations:
+
+- **Dynamic DNS service provider:** Select other and enter **dynamicdns.park-your-domain.com**.
+- **Dynamic DNS update protocol:** Press **Enter**. You'll need to manually change this later.
+- **Username for dynamic DNS service:** Enter your domain name.
+- **Password for dynamic DNS service:** Enter the password you received after enabling DDNS in your domain name service provider account.
+- **Network interface used for dynamic DNS service:** Enter **dynamicdns.park-your-domain.com/getip**. You'll need to modify the network interface later.
+- **DyDNS fully qualified domain names:** Enter the **subdomain** that you specified when setting up. If you'll be running your proxy server without using subdomain, enter **@**.
+
+Now, you'll need to further modify the DDNS configuration file. In **Terminal**, open the ddclient configuration file by running the following command:
+
+```console
+sudo nano /etc/ddclient.conf
+```
+
+To configure how often ddclient will update the DNS, add the following line to the top of the configurations in the file:
+
+```console
+...
+daemon=3600
+...
+```
+
+!!! note
+
+    `3600` means that ddclient will check for changes to the public IP address every 3,600 seconds, which equals once an hour. You can adjust this value to be longer or shorter.
+
+Then, set `protocol` to your domain name service provider (as specified in your domain name service provider's documentation) and set `use` to `web`. The configuration file should then look as follows:
+
+```console
+# Configuration file for ddclient generated by debconf
+#
+# /etc/ddclient.conf
+daemon=3600
+protocol=<DOMAIN_NAME_SERVICE_PROVIDER>
+use=web, web=dynamicdns.park-your-domain.com/getip
+server=dynamicdns.park-your-domain.com
+login=<DOMAIN_NAME>.<TOP_LEVEL_DOMAIN>
+password=<DDNS_PASSWORD>
+<SUBDOMAIN>
+```
+
+Save your changes, and close the file. You can check if the configuration is working by running the following command:
+
+```console
+sudo ddclient -daemon=0 -debug -verbose -noquiet
+```
+
+!!! note
+
+    If you see any `invalid` or `error` outputs after running the above command, check the settings in your ddclient configuration file.
+
+To confirm that ddclient is running in daemon mode, run the following command to open the ddclient system file:
+
+```console
+sudo nano /etc/default/ddclient
+```
+
+Confirm that `run_daemon` is set to `true`, then close the file.
+
+To start the ddclient daemon, run the following command:
+
+```console
+sudo service ddclient start
+```
+
+To check the status of ddclient, run the following command:
+
+```console
+sudo service ddclient status
+```
+
+## Set up and connect to your Signal TLS proxy server
+
+After setting up the DNS record for your domain name in your domain name service provider account, changing the hostname of your OS, and configuring ddclient on your OS, you can set up the Signal TLS proxy server.
+
+### Set up the Signal TLS proxy server
+
+In **Terminal**, clone **[Signal-TLS-Proxy](https://github.com/signalapp/Signal-TLS-Proxy)** by running the following command and go to that folder:
+
+```console
+git clone https://github.com/signalapp/Signal-TLS-Proxy
+cd Signal-TLS-Proxy
+```
+
+Run **init-certificate.sh** by running the following command:
+
+```console
+./init-certificate.sh
+```
+
+After running the bash script, follow the certificate setup instructions shown in Terminal.
+
+After setting up the certificate, start the **Docker container** to run your proxy server by running the following command:
+
+```console
+docker-compose up
+```
+
+!!! note
+
+    To start your proxy server in the background without showing an output in Terminal, run the following command:
+    
+    ```console
+    docker-compose up --detach
+    ``` 
+
+Your Signal TLS proxy server should now be running. If you encounter issues, see [Troubleshooting](#troubleshooting)
+
+### Connect to your proxy server
+
+To connect to your proxy server, open a web browser on your mobile device and enter `https://signal.tube/#<SUBDOMAIN>.<DOMAIN_NAME>.<TOP_LEVEL_DOMAIN>` into a mobile web browser, replacing `<SUBDOMAIN>.<DOMAIN_NAME>.<TOP_LEVEL_DOMAIN>` with the details of the domain name you previously set up.
+   
+!!! note
+
+    You can also connect directly to the proxy server by adding the `<SUBDOMAIN>.<DOMAIN_NAME>.<TOP_LEVEL_DOMAIN>` (without `https://`) in the settings in the Signal app.
+    
+    Keep in mind that the Signal desktop app currently does not support proxy connections.
+
+The following are the different shield statuses in the Signal app:
+
+- **Green shield:** Indicates that you're connected to the Signal TLS proxy server.
+- **Gray shield:** Indicates that you're trying to connect to the proxy server. 
+- **Red shield:** Indicates that you're no longer connected, which could mean the proxy server is down or otherwise no longer available.
+
+After confirming that your proxy server is working, be sure to monitor your setup periodically.
+
+### Shut down your proxy server
+
+To stop the Docker container that your proxy server is running on, run the following command:
+
+```console
+docker-compose down
+```
+
+## Troubleshooting
+
+If you're unable to start your Signal TLS proxy server after shutting it down, open **Terminal** and run the following group of commands:
+
+```console
+cd Signal-TLS-Proxy # Goes to the Signal-TLS-Proxy folder.
+./init-certificate.sh # Runs the certificate script.
+git pull # Pings the Signal-TLS-Proxy repository for any changes.
+docker-compose down # Stops the Docker container.
+docker-compose up # Starts the Docker container.
+```


### PR DESCRIPTION
## Description

This PR adds a blog post for setting up a Signal TLS proxy server.

## Related issues and/or PRs

N/A

## Changes made

- Create blog post that describes how to set up a Signal TLS proxy server on a Linux-based OS.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
