### PR TITLE
Update "How to set up a Signal TLS proxy server" blog post

### DIFF
--- a/blog/posts/2024-01-08-setting-up-signal-proxy.md
+++ b/blog/posts/2024-01-08-setting-up-signal-proxy.md
@@ -17,15 +17,17 @@ I wrote this post because the official Signal TLS proxy server repository lacks 
 
 <!-- more -->
 
+!!! warning "Attention"
+
+    For security reasons, you should avoid running a server of any type on your home network. If you decide to run a server on your home network, please understand that you're putting your network and at significant risk of being compromised.  
+
 ## Why run a proxy server?
 
 Government officials are known to occasionally block access to apps in their countries, especially during times of social unrest and when they don't want information widely shared.
 
 By running a Signal proxy server, you can enable people in other countries to connect to Signal and stay in contact with friends and family.
 
-!!! warning "Attention"
-
-    For security reasons, you should avoid running a server of any type on your home network. If you decide to run a server on your home network, please understand that you're putting your network and at significant risk of being compromised.  
+For reference, you can see which countries have temporarily or permanently blocked connections to Signal in 2023, courtesy of the Open Observatory of Network Interference (OONI): [OONI Explorer](https://explorer.ooni.org/search?since=2023-01-01&test_name=signal&failure=false&only=anomalies&until=2023-12-31)
 
 ## Set up your domain
 


### PR DESCRIPTION
## Description

This PR updates the [How to set up a Signal TLS proxy server](https://github.com/josh-wong/josh-wong.github.io/blob/75c9c9b692e8ed2b5b0a2c4ddb9a5848cf79c222/blog/posts/2024-01-08-setting-up-signal-proxy.md) blog post with some additional context about countries that have blocked Signal.

## Related issues and/or PRs

- https://github.com/josh-wong/josh-wong.github.io/pull/20

## Changes made

- Added a paragraph about OONI Explorer as a reference so that users can check which countries have blocked Signal in 2023.
- Moved an Attention section.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A