### PR TITLE
Hide broken links in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -123,50 +123,50 @@ const config = {
       },
       footer: {
         style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Creative',
-                to: '/docs/creative',
-              },
-              {
-                label: 'Notes',
-                to: '/docs/notes',
-              },
-              {
-                label: 'Scripts',
-                to: '/docs/scripts',
-              },
-              {
-                label: 'Software',
-                to: '/docs/software',
-              },
-              {
-                label: 'Tutorials',
-                to: '/docs/tutorials',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/josh-wong',
-              },
-              {
-                label: 'LinkedIn',
-                href: 'https://www.linkedin.com/in/wongjoshua',
-              },
-              {
-                label: 'Twitter',
-                href: 'https://twitter.com/080F53',
-              },
-            ],
-          },
-        ],
+        // links: [
+        //   {
+        //     title: 'Docs',
+        //     items: [
+        //       {
+        //         label: 'Creative',
+        //         to: '/docs/creative',
+        //       },
+        //       {
+        //         label: 'Notes',
+        //         to: '/docs/notes',
+        //       },
+        //       {
+        //         label: 'Scripts',
+        //         to: '/docs/scripts',
+        //       },
+        //       {
+        //         label: 'Software',
+        //         to: '/docs/software',
+        //       },
+        //       {
+        //         label: 'Tutorials',
+        //         to: '/docs/tutorials',
+        //       },
+        //     ],
+        //   },
+        //   {
+        //     title: 'Community',
+        //     items: [
+        //       {
+        //         label: 'GitHub',
+        //         href: 'https://github.com/josh-wong',
+        //       },
+        //       {
+        //         label: 'LinkedIn',
+        //         href: 'https://www.linkedin.com/in/wongjoshua',
+        //       },
+        //       {
+        //         label: 'Twitter',
+        //         href: 'https://twitter.com/080F53',
+        //       },
+        //     ],
+        //   },
+        // ],
         copyright: `Copyright © ${new Date().getFullYear()} 080F53`,
       },
       prism: {


### PR DESCRIPTION
## Description

This PR hides the links in the footer, which are currently broken. I'll replace those links in the future when the site has matured.

## Related issues and/or PRs

N/A

## Changes made

- Commented out the links in the footer in the Docusaurus configuration file.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have documented or updated any remaining open issues linked to this PR.
- [x] I have confirmed that my changes generate no new warnings.
- [x] I have merged any dependent changes in other PRs into this PR or otherwise addressed.

## Additional notes (optional)

N/A