### PR TITLE
Add workflows that auto-create PRs

### DIFF
--- a/.github/workflows/auto-create-pr-bitcoin-cash-node-on-raspberry-pi.yml
+++ b/.github/workflows/auto-create-pr-bitcoin-cash-node-on-raspberry-pi.yml
@@ -1,0 +1,40 @@
+# This workflow auto-creates PRs for docs that have been updated in my "bitcoin-cash-node-on-raspberry-pi" repository.
+name: ✨ Auto-create PR - bitcoin-cash-node-on-raspberry-pi docs
+
+on:
+  push:
+    branches:
+      - bitcoin-cash-node-on-raspberry-pi/**
+      - passgen/**
+      - zune-software-setup/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs sync - `bitcoin-cash-node-on-raspberry-pi`',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to docs in the [josh-wong/bitcoin-cash-node-on-raspberry-pi](https://github.com/josh-wong/bitcoin-cash-node-on-raspberry-pi) repo to this repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'triage']
+            });

--- a/.github/workflows/auto-create-pr-passgen.yml
+++ b/.github/workflows/auto-create-pr-passgen.yml
@@ -1,0 +1,38 @@
+# This workflow auto-creates PRs for docs that have been updated in my "passgen" repository.
+name: ✨ Auto-create PR - passgen docs
+
+on:
+  push:
+    branches:
+      - passgen/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs sync - `passgen`',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to docs in the [josh-wong/passgen](https://github.com/josh-wong/passgen) repo to this repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'triage']
+            });

--- a/.github/workflows/auto-create-pr-zune-software-setup.yml
+++ b/.github/workflows/auto-create-pr-zune-software-setup.yml
@@ -1,0 +1,38 @@
+# This workflow auto-creates PRs for docs that have been updated in my "zune-software-setup" repository.
+name: ✨ Auto-create PR - zune-software-setup docs
+
+on:
+  push:
+    branches:
+      - zune-software-setup/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs sync - `zune-software-setup`',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to docs in the [josh-wong/zune-software-setup](https://github.com/josh-wong/zune-software-setup) repo to this repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'triage']
+            });


### PR DESCRIPTION
## Description

> Provide a brief description about **why** this PR is necessary. Be sure to provide context.

This PR adds workflows that auto-create PRs when docs-related PRs in certain GitHub repositories have been updated. This workflow should reduce the time I spend having to manually add docs and create PRs.

## Related issues or PRs

- Based on workflows added in the following PRs:
  - https://github.com/josh-wong/bitcoin-cash-node-on-raspberry-pi/pull/10
  - https://github.com/josh-wong/passGen/pull/3
  - https://github.com/josh-wong/zune-software-setup/pull/17

## Changes made

- Created workflows to sync updated docs from source repositories to this repository based on branch-naming patterns.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR, add `N/A` after each item.

### Documentation

- [ ] I have updated the side navigation as necessary. `N/A`
- [ ] I have updated the documentation to reflect the changes. `N/A`
- [ ] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [ ] I have merged and published any dependent changes in other PRs. `N/A`
- [ ] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [ ] I have checked that my documentation looks as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
