### PR TITLE
Move tags to top of blog posts and docs

### DIFF
--- a/docs/portfolio/index.mdx
+++ b/docs/portfolio/index.mdx
@@ -1,3 +1,9 @@
+---
+tags:
+  - "Personal portfolio"
+  - "Professional portfolio"
+---
+
 # Overview
 
 import { CardRowProfessionalProjects, CardRowPersonalProjects } from '/src/components/Cards/projects';

--- a/docs/portfolio/index.mdx
+++ b/docs/portfolio/index.mdx
@@ -4,6 +4,6 @@ import { CardRowProfessionalProjects, CardRowPersonalProjects } from '/src/compo
 
 The following are some samples of projects that I've worked on.
 
-## Personal project samples
+## Personal portfolio samples
 
 <CardRowPersonalProjects />

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,7 +39,7 @@ const sidebars = {
     // },
     {
       type: 'category',
-      label: 'Personal samples',
+      label: 'Personal portfolio samples',
       items: [
         {
           type: 'category',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -135,6 +135,10 @@ html[data-theme="dark"] .badge {
   margin-top: 0 !important;
 }
 
+.docusaurus-mt-lg {
+  margin-top: 1rem !important;
+}
+
 .theme-blog-footer-edit-meta-row {
   padding: 0.5rem 0;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -135,6 +135,10 @@ html[data-theme="dark"] .badge {
   margin-top: 0 !important;
 }
 
+.row, .margin-top--sm .theme-blog-footer-edit-meta-row {
+  padding: 0.5rem 0;
+}
+
 /* RSS icon*/
 .header-rss-link::before {
   display: block;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -135,7 +135,7 @@ html[data-theme="dark"] .badge {
   margin-top: 0 !important;
 }
 
-.row, .margin-top--sm .theme-blog-footer-edit-meta-row {
+.theme-blog-footer-edit-meta-row {
   padding: 0.5rem 0;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -104,6 +104,37 @@ html[data-theme="dark"] .navbar-sidebar .header-github-link {
   filter: invert(0%);
 }
 
+/* Add styles for tags that appear above page titles */
+
+.badge {
+  border: none;
+  font-size: 85%;
+  line-height: 2;
+  margin: 0.25rem 0 1rem 0;
+  padding-top: 0.5rem;
+  width: -webkit-fill-available;
+}
+
+html[data-theme="dark"] .badge {
+  background-color: #090a11;
+  border: none;
+  color: white;
+  font-size: 85%;
+  line-height: 2;
+  margin: 0.25rem 0 1rem 0;
+  padding-top: 0.5rem;
+  width: -webkit-fill-available;
+}
+
+.theme-doc-footer-tags-row {
+  display: inline-flex;
+  float: inline-start;
+}
+
+.margin-top--sm, .margin-vert--sm {
+  margin-top: 0 !important;
+}
+
 /* RSS icon*/
 .header-rss-link::before {
   display: block;

--- a/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
+++ b/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+import type {Props} from '@theme/BlogPostItem/Footer/ReadMoreLink';
+
+function ReadMoreLabel() {
+  return (
+    <b>
+      <Translate
+        id="theme.blog.post.readMore"
+        description="The label used in blog post item excerpts to link to full blog posts">
+        Read More
+      </Translate>
+    </b>
+  );
+}
+
+export default function BlogPostItemFooterReadMoreLink(
+  props: Props,
+): JSX.Element {
+  const {blogPostTitle, ...linkProps} = props;
+  return (
+    <Link
+      aria-label={translate(
+        {
+          message: 'Read more about {title}',
+          id: 'theme.blog.post.readMoreLabel',
+          description:
+            'The ARIA label for the link to full blog posts from excerpts',
+        },
+        {title: blogPostTitle},
+      )}
+      {...linkProps}>
+      <ReadMoreLabel />
+    </Link>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import EditMetaRow from '@theme/EditMetaRow';
+import TagsListInline from '@theme/TagsListInline';
+import ReadMoreLink from '@theme/BlogPostItem/Footer/ReadMoreLink';
+
+export default function BlogPostItemFooter(): JSX.Element | null {
+  const {metadata, isBlogPostPage} = useBlogPost();
+  const {
+    tags,
+    title,
+    editUrl,
+    hasTruncateMarker,
+    lastUpdatedBy,
+    lastUpdatedAt,
+  } = metadata;
+
+  // A post is truncated if it's in the "list view" and it has a truncate marker
+  const truncatedPost = !isBlogPostPage && hasTruncateMarker;
+
+  const tagsExists = tags.length > 0;
+
+  const renderFooter = tagsExists || truncatedPost || editUrl;
+
+  if (!renderFooter) {
+    return null;
+  }
+
+  // BlogPost footer - details view
+  if (isBlogPostPage) {
+    const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
+
+    return (
+      <footer className="docusaurus-mt-lg">
+        {tagsExists && (
+          <div
+            className={clsx(
+              'row',
+              'margin-top--sm',
+              ThemeClassNames.blog.blogFooterEditMetaRow,
+            )}>
+            <div className="col">
+              <TagsListInline tags={tags} />
+            </div>
+          </div>
+        )}
+        {canDisplayEditMetaRow && (
+          <EditMetaRow
+            className={clsx(
+              'margin-top--sm',
+              ThemeClassNames.blog.blogFooterEditMetaRow,
+            )}
+            editUrl={editUrl}
+            lastUpdatedAt={lastUpdatedAt}
+            lastUpdatedBy={lastUpdatedBy}
+          />
+        )}
+      </footer>
+    );
+  }
+  // BlogPost footer - list view
+  else {
+    return (
+      <footer className="row docusaurus-mt-lg">
+        {tagsExists && (
+          <div className={clsx('col', {'col--9': truncatedPost})}>
+            <TagsListInline tags={tags} />
+          </div>
+        )}
+        {truncatedPost && (
+          <div
+            className={clsx('col text--right', {
+              'col--3': tagsExists,
+            })}>
+            <ReadMoreLink blogPostTitle={title} to={metadata.permalink} />
+          </div>
+        )}
+      </footer>
+    );
+  }
+}

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -64,16 +64,14 @@ export default function BlogPostItemFooter(): JSX.Element | null {
   else {
     return (
       <footer className="row docusaurus-mt-lg">
-        {tagsExists && (
+        {/* {tagsExists && (
           <div className={clsx('col', {'col--9': truncatedPost})}>
             <TagsListInline tags={tags} />
           </div>
-        )}
+        )} */}
         {truncatedPost && (
           <div
-            className={clsx('col text--right', {
-              'col--3': tagsExists,
-            })}>
+            className={clsx('col text--left')}>
             <ReadMoreLink blogPostTitle={title} to={metadata.permalink} />
           </div>
         )}

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -34,7 +34,7 @@ export default function BlogPostItemFooter(): JSX.Element | null {
 
     return (
       <footer className="docusaurus-mt-lg">
-        {tagsExists && (
+        {/* {tagsExists && (
           <div
             className={clsx(
               'row',
@@ -45,7 +45,7 @@ export default function BlogPostItemFooter(): JSX.Element | null {
               <TagsListInline tags={tags} />
             </div>
           </div>
-        )}
+        )} */}
         {canDisplayEditMetaRow && (
           <EditMetaRow
             className={clsx(

--- a/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {usePluralForm} from '@docusaurus/theme-common';
+import {
+  useBlogPost,
+  useDateTimeFormat,
+} from '@docusaurus/theme-common/internal';
+import type {Props} from '@theme/BlogPostItem/Header/Info';
+
+import styles from './styles.module.css';
+
+// Very simple pluralization: probably good enough for now
+function useReadingTimePlural() {
+  const {selectMessage} = usePluralForm();
+  return (readingTimeFloat: number) => {
+    const readingTime = Math.ceil(readingTimeFloat);
+    return selectMessage(
+      readingTime,
+      translate(
+        {
+          id: 'theme.blog.post.readingTime.plurals',
+          description:
+            'Pluralized label for "{readingTime} min read". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+          message: 'One min read|{readingTime} min read',
+        },
+        {readingTime},
+      ),
+    );
+  };
+}
+
+function ReadingTime({readingTime}: {readingTime: number}) {
+  const readingTimePlural = useReadingTimePlural();
+  return <>{readingTimePlural(readingTime)}</>;
+}
+
+function DateTime({
+  date,
+  formattedDate,
+}: {
+  date: string;
+  formattedDate: string;
+}) {
+  return <time dateTime={date}>{formattedDate}</time>;
+}
+
+function Spacer() {
+  return <>{' · '}</>;
+}
+
+export default function BlogPostItemHeaderInfo({
+  className,
+}: Props): JSX.Element {
+  const {metadata} = useBlogPost();
+  const {date, readingTime} = metadata;
+
+  const dateTimeFormat = useDateTimeFormat({
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  const formatDate = (blogDate: string) =>
+    dateTimeFormat.format(new Date(blogDate));
+
+  return (
+    <div className={clsx(styles.container, 'margin-vert--md', className)}>
+      <DateTime date={date} formattedDate={formatDate(date)} />
+      {typeof readingTime !== 'undefined' && (
+        <>
+          <Spacer />
+          <ReadingTime readingTime={readingTime} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -58,8 +58,6 @@ export default function BlogPostItemHeaderInfo({
 
   const tagsExists = tags.length > 0;
 
-  const renderFooter = tagsExists;
-
   const dateTimeFormat = useDateTimeFormat({
     day: 'numeric',
     month: 'long',

--- a/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
-import {usePluralForm} from '@docusaurus/theme-common';
+import {usePluralForm, ThemeClassNames} from '@docusaurus/theme-common';
 import {
   useBlogPost,
   useDateTimeFormat,
 } from '@docusaurus/theme-common/internal';
 import type {Props} from '@theme/BlogPostItem/Header/Info';
+import TagsListInline from '@theme/TagsListInline';
 
 import styles from './styles.module.css';
 
@@ -53,7 +54,11 @@ export default function BlogPostItemHeaderInfo({
   className,
 }: Props): JSX.Element {
   const {metadata} = useBlogPost();
-  const {date, readingTime} = metadata;
+  const {date, readingTime, tags} = metadata;
+
+  const tagsExists = tags.length > 0;
+
+  const renderFooter = tagsExists;
 
   const dateTimeFormat = useDateTimeFormat({
     day: 'numeric',
@@ -67,6 +72,18 @@ export default function BlogPostItemHeaderInfo({
 
   return (
     <div className={clsx(styles.container, 'margin-vert--md', className)}>
+      {tagsExists && (
+        <div
+          className={clsx(
+            'row',
+            'margin-top--sm',
+            ThemeClassNames.blog.blogFooterEditMetaRow,
+          )}>
+          <div className="col">
+            <TagsListInline tags={tags} />
+          </div>
+        </div>
+      )}
       <DateTime date={date} formattedDate={formatDate(date)} />
       {typeof readingTime !== 'undefined' && (
         <>

--- a/src/theme/BlogPostItem/Header/Info/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Info/styles.module.css
@@ -1,0 +1,3 @@
+.container {
+  font-size: 0.9rem;
+}

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/theme-common/internal';
+import TagsListInline from '@theme/TagsListInline';
+
+import EditMetaRow from '@theme/EditMetaRow';
+
+export default function DocItemFooter(): JSX.Element | null {
+  const {metadata} = useDoc();
+  const {editUrl, lastUpdatedAt, lastUpdatedBy, tags} = metadata;
+
+  const canDisplayTagsRow = tags.length > 0;
+  const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
+
+  const canDisplayFooter = canDisplayTagsRow || canDisplayEditMetaRow;
+
+  if (!canDisplayFooter) {
+    return null;
+  }
+
+  return (
+    <footer
+      className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}>
+      {canDisplayTagsRow && (
+        <div
+          className={clsx(
+            'row margin-top--sm',
+            ThemeClassNames.docs.docFooterTagsRow,
+          )}>
+          <div className="col">
+            <TagsListInline tags={tags} />
+          </div>
+        </div>
+      )}
+      {canDisplayEditMetaRow && (
+        <EditMetaRow
+          className={clsx(
+            'margin-top--sm',
+            ThemeClassNames.docs.docFooterEditMetaRow,
+          )}
+          editUrl={editUrl}
+          lastUpdatedAt={lastUpdatedAt}
+          lastUpdatedBy={lastUpdatedBy}
+        />
+      )}
+    </footer>
+  );
+}

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -22,7 +22,8 @@ export default function DocItemFooter(): JSX.Element | null {
   return (
     <footer
       className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}>
-      {canDisplayTagsRow && (
+      {/* Commented out tags since we've added them to the top of docs. (See src/theme/DocVersionBadge/index.tsx) */}
+      {/* {canDisplayTagsRow && (
         <div
           className={clsx(
             'row margin-top--sm',
@@ -32,7 +33,7 @@ export default function DocItemFooter(): JSX.Element | null {
             <TagsListInline tags={tags} />
           </div>
         </div>
-      )}
+      )} */}
       {canDisplayEditMetaRow && (
         <EditMetaRow
           className={clsx(

--- a/src/theme/DocVersionBadge/index.tsx
+++ b/src/theme/DocVersionBadge/index.tsx
@@ -14,7 +14,7 @@ export default function DocVersionBadge({
   const {tags} = metadata;
 
   const versionMetadata = useDocsVersion();
-  if (versionMetadata.badge) {
+  // if (versionMetadata.badge) {
     return (
       <span
         className={clsx(
@@ -22,11 +22,12 @@ export default function DocVersionBadge({
           ThemeClassNames.docs.docVersionBadge,
           'badge badge--secondary',
         )}>
-        <Translate
+        {/* The following is commented out since my personal portfolio doesn't have versioned docs. */}
+        {/* <Translate
           id="theme.docs.versionBadge.label"
           values={{versionLabel: versionMetadata.label}}>
           {'Version: {versionLabel}'}
-        </Translate>
+        </Translate> */}
         <div
           className={clsx(
             'row margin-top--sm',
@@ -38,6 +39,6 @@ export default function DocVersionBadge({
         </div>
       </span>
     );
-  }
+  //}
   return null;
 }

--- a/src/theme/DocVersionBadge/index.tsx
+++ b/src/theme/DocVersionBadge/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useDocsVersion} from '@docusaurus/theme-common/internal';
+import type {Props} from '@theme/DocVersionBadge';
+
+export default function DocVersionBadge({
+  className,
+}: Props): JSX.Element | null {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.badge) {
+    return (
+      <span
+        className={clsx(
+          className,
+          ThemeClassNames.docs.docVersionBadge,
+          'badge badge--secondary',
+        )}>
+        <Translate
+          id="theme.docs.versionBadge.label"
+          values={{versionLabel: versionMetadata.label}}>
+          {'Version: {versionLabel}'}
+        </Translate>
+      </span>
+    );
+  }
+  return null;
+}

--- a/src/theme/DocVersionBadge/index.tsx
+++ b/src/theme/DocVersionBadge/index.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDocsVersion} from '@docusaurus/theme-common/internal';
+import {useDocsVersion, useDoc} from '@docusaurus/theme-common/internal';
 import type {Props} from '@theme/DocVersionBadge';
+import TagsListInline from '@theme/TagsListInline';
 
 export default function DocVersionBadge({
   className,
 }: Props): JSX.Element | null {
+
+  const {metadata} = useDoc();
+  const {tags} = metadata;
+
   const versionMetadata = useDocsVersion();
   if (versionMetadata.badge) {
     return (
@@ -22,6 +27,15 @@ export default function DocVersionBadge({
           values={{versionLabel: versionMetadata.label}}>
           {'Version: {versionLabel}'}
         </Translate>
+        <div
+          className={clsx(
+            'row margin-top--sm',
+            ThemeClassNames.docs.docFooterTagsRow,
+          )}>
+          <div className="col">
+            <TagsListInline tags={tags} />
+          </div>
+        </div>
       </span>
     );
   }

--- a/src/theme/TagsListInline/index.tsx
+++ b/src/theme/TagsListInline/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Tag from '@theme/Tag';
+import type {Props} from '@theme/TagsListInline';
+
+import styles from './styles.module.css';
+
+export default function TagsListInline({tags}: Props): JSX.Element {
+  return (
+    <>
+      <b>
+        <Translate
+          id="theme.tags.tagsListLabel"
+          description="The label alongside a tag list">
+          Tags:
+        </Translate>
+      </b>
+      <ul className={clsx(styles.tags, 'padding--none', 'margin-left--sm')}>
+        {tags.map((tag) => (
+          <li key={tag.permalink} className={styles.tag}>
+            <Tag {...tag} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/theme/TagsListInline/styles.module.css
+++ b/src/theme/TagsListInline/styles.module.css
@@ -1,0 +1,8 @@
+.tags {
+  display: inline;
+}
+
+.tag {
+  margin: 0 0.4rem 0.5rem 0;
+  display: inline-block;
+}


### PR DESCRIPTION
## Description

> Provide a brief description about **why** this PR is necessary. Be sure to provide context.

This PR moves tags to the top of blog posts and docs. The tags feature exists natively for pages in the `blog` and `docs` folders, but the tags appear at the bottom of pages. Some customization is needed to move the tags to the top of pages, which this PR addresses.

## Related issues and/or PRs

> Add a link to any existing issues and/or PRs. Or, write `N/A` if no related issues and/or PRs exist.

N/A

## Changes made

> Outline the specific changes made in this pull request in the form of a bulleted list. Include relevant details, such as added features, bug fixes, code refactoring, or improvements.

- Swizzled the `@docusaurus/theme-classic` theme:
  - Removed the tags from the bottom of the page in `DocItem/Footer` and `BlogPostItem/Footer`.
  - Added tags to the top of the page in `DocVersionBadge` and `BlogPostItem/Header`.
- Added styles for tags.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR, add `N/A` after each item.

### Documentation

- [ ] I have updated the side navigation as necessary. `N/A`
- [ ] I have updated the documentation to reflect the changes. `N/A`
- [ ] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [ ] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
