### PR TITLE
Fix Better Status badge text color

### DIFF
--- a/src/theme/Footer/Links/MultiColumn/index.js
+++ b/src/theme/Footer/Links/MultiColumn/index.js
@@ -33,7 +33,7 @@ export default function FooterLinksMultiColumn({columns}) {
       {columns.map((column, i) => (
         <Column key={i} column={column} />
       ))}
-      &nbsp;&nbsp;<iframe src="https://status.080f53.com/badge" width="200" height="30" frameborder="0" scrolling="no"></iframe>
+      &nbsp;&nbsp;<iframe src="https://status.080f53.com/badge?theme=dark" width="200" height="30" frameborder="0" scrolling="no"></iframe>
     </div>
     
     </>


### PR DESCRIPTION
## Description

> Provide a brief description about **why** this PR is necessary. Be sure to provide context.

This PR fixes the color of the Better Status badge in the footer. Since the mode wasn't specified, the text defaulted to dark gray, which is the same color as the footer, making the text not appear.

## Related issues and/or PRs

> Add a link to any existing issues and/or PRs. Or, write `N/A` if no related issues and/or PRs exist.

- #53 

## Changes made

> Outline the specific changes made in this pull request in the form of a bulleted list. Include relevant details, such as added features, bug fixes, code refactoring, or improvements.

- Specific `?theme=dark` in the badge iframe, which changes the color to white.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR, add `N/A` after each item.

### Documentation

- [ ] I have updated the side navigation as necessary. `N/A`
- [ ] I have updated the documentation to reflect the changes. `N/A`
- [ ] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [ ] I have merged and published any dependent changes in other PRs. `N/A`
- [ ] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
