### PR TITLE
Upgrade Docusaurus from 3.4.0 to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@crowdin/cli": "^3.19.4",
-        "@docusaurus/core": "^3.4.0",
-        "@docusaurus/plugin-content-docs": "^3.4.0",
-        "@docusaurus/plugin-google-gtag": "^3.4.0",
-        "@docusaurus/plugin-google-tag-manager": "^3.4.0",
-        "@docusaurus/plugin-pwa": "^3.4.0",
-        "@docusaurus/preset-classic": "^3.4.0",
-        "@docusaurus/theme-mermaid": "^3.4.0",
+        "@docusaurus/core": "^3.5.1",
+        "@docusaurus/plugin-content-docs": "^3.5.1",
+        "@docusaurus/plugin-google-gtag": "^3.5.1",
+        "@docusaurus/plugin-google-tag-manager": "^3.5.1",
+        "@docusaurus/plugin-pwa": "^3.5.1",
+        "@docusaurus/preset-classic": "^3.5.1",
+        "@docusaurus/theme-mermaid": "^3.5.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "docusaurus-plugin-image-zoom": "^2.0.0",
@@ -25,8 +25,8 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.4.0",
-        "@docusaurus/types": "^3.4.0"
+        "@docusaurus/module-type-aliases": "^3.5.1",
+        "@docusaurus/types": "^3.5.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -36,6 +36,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
       "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+      "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
         "@algolia/autocomplete-shared": "1.9.3"
@@ -45,6 +46,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
       "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -56,6 +58,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
       "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+      "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -68,147 +71,164 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
       "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.23.3.tgz",
-      "integrity": "sha512-vRHXYCpPlTDE7i6UOy2xE03zHF2C8MEFjPN2v7fRbqVpcOvAUQK81x3Kc21xyb5aSIpYCjWCZbYZuz8Glyzyyg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.23.3.tgz",
-      "integrity": "sha512-h9XcNI6lxYStaw32pHpB1TMm0RuxphF+Ik4o7tcQiodEdpKK+wKufY6QXtba7t3k8eseirEMVB83uFFF3Nu54A=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g==",
+      "license": "MIT"
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.23.3.tgz",
-      "integrity": "sha512-yvpbuUXg/+0rbcagxNT7un0eo3czx2Uf0y4eiR4z4SD7SiptwYTpbuS0IHxcLHG3lq22ukx1T6Kjtk/rT+mqNg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.23.3.tgz",
-      "integrity": "sha512-hpa6S5d7iQmretHHF40QGq6hz0anWEHGlULcTIT9tbUssWUriN9AUXIFQ8Ei4w9azD0hc1rUok9/DeQQobhQMA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.23.3.tgz",
-      "integrity": "sha512-LBsEARGS9cj8VkTAVEZphjxTjMVCci+zIIiRhpFun9jGDUlS1XmhCW7CTrnaWeIuCQS/2iPyRqSy1nXPjcBLRA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.23.3.tgz",
-      "integrity": "sha512-l6EiPxdAlg8CYhroqS5ybfIczsGUIAC47slLPOMDeKSVXYG1n0qGiz4RjAHLw2aD0xzh2EXZ7aRguPfz7UKDKw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.23.3.tgz",
-      "integrity": "sha512-3E3yF3Ocr1tB/xOZiuC3doHQBQ2zu2MPTYZ0d4lpfWads2WTKG7ZzmGnsHmm63RflvDeLK/UVx7j2b3QuwKQ2g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.23.3.tgz",
-      "integrity": "sha512-P4VAKFHqU0wx9O+q29Q8YVuaowaZ5EM77rxfmGnkHUJggh28useXQdopokgwMeYw2XUht49WX5RcTQ40rZIabw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/events": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
-      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==",
+      "license": "MIT"
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.23.3.tgz",
-      "integrity": "sha512-y9kBtmJwiZ9ZZ+1Ek66P0M68mHQzKRxkW5kAAXYN/rdzgDN0d2COsViEFufxJ0pb45K4FRcfC7+33YB4BLrZ+g=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA==",
+      "license": "MIT"
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.23.3.tgz",
-      "integrity": "sha512-8xoiseoWDKuCVnWP8jHthgaeobDLolh00KJAdMe9XPrWPuf1by732jSpgy2BlsLTaT9m32pHI8CRfrOqQzHv3A==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/logger-common": "4.23.3"
+        "@algolia/logger-common": "4.24.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.23.3.tgz",
-      "integrity": "sha512-9fK4nXZF0bFkdcLBRDexsnGzVmu4TSYZqxdpgBW2tEyfuSSY54D4qSRkLmNkrrz4YFvdh2GM1gA8vSsnZPR73w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.3",
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/cache-in-memory": "4.23.3",
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/logger-console": "4.23.3",
-        "@algolia/requester-browser-xhr": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/requester-node-http": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.3.tgz",
-      "integrity": "sha512-jDWGIQ96BhXbmONAQsasIpTYWslyjkiGu0Quydjlowe+ciqySpiDUrJHERIRfELE5+wFc7hc1Q5hqjGoV7yghw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.23.3.tgz",
-      "integrity": "sha512-xloIdr/bedtYEGcXCiF2muajyvRhwop4cMZo+K2qzNht0CMzlRkm8YsDdj5IaBhshqfgmBb3rTg4sL4/PpvLYw=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA==",
+      "license": "MIT"
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.23.3.tgz",
-      "integrity": "sha512-zgu++8Uj03IWDEJM3fuNl34s746JnZOWn1Uz5taV1dFyJhVM/kTNw9Ik7YJWiUNHJQXcaD8IXD1eCb0nq/aByA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.23.3.tgz",
-      "integrity": "sha512-Wjl5gttqnf/gQKJA+dafnD0Y6Yw97yvfY8R9h0dQltX1GXTgNs1zWgvtWW0tHl1EgMdhAyw189uWiZMnL3QebQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2140,18 +2160,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
-      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.1.tgz",
+      "integrity": "sha512-VtVb5DS+0hRIprU2CO6ZQjK2Zg4QU5HrDM1+ix6rT0umsYvFvatMAnf97NHZlVWDaaLlx7GRfR/7FikANiM2Fg==",
+      "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
-      "integrity": "sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.1.tgz",
+      "integrity": "sha512-qXZkEPvybVhSXj0K7U3bXc233tk5e8PfhoZ6MhPOiik/qUQxYC+Dn9DnoS7CxHQQhHfCvTiN0eY9M12oRghEXw==",
+      "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.9.3",
         "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.6.0",
+        "@docsearch/css": "3.6.1",
         "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
@@ -2176,9 +2198,10 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-N3+9IbGI2jbkiRc6ZbEnU9dC02nHQXi8ivM1VJldkPQyP7WlyHXS+NDhmL3rwaYOMbGH96X2LcKigCKg7pEEqg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2190,12 +2213,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/cssnano-preset": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2261,9 +2284,10 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
-      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.1.tgz",
+      "integrity": "sha512-mvtWPLWePlm+4doepxMUT5ynsJQ3CgPtDdbaQh9wm3iAE/7OATBpSgLlfz5N+YtxI5bjIErjbkH8yzISP+S65g==",
+      "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
         "postcss": "^8.4.38",
@@ -2275,9 +2299,10 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.1.tgz",
+      "integrity": "sha512-B36a88CEHCtxIylAV1HNuiiISpoKBqm0UxA6a/JwtHX++Dxb7LNDSGs8ELBlQsZN0OG2tX3tBsCWyaLPwYorkQ==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2287,13 +2312,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
-      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.1.tgz",
+      "integrity": "sha512-D6Ea2dt32xhoqH+1EuHLGDVSX2HLFiR4QpI0GTU46qOu2hb2ChpQENIUZ2inOsdGFunNa0fCnDG3qn7Kdbzq1A==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2325,11 +2351,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
-      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.1.tgz",
+      "integrity": "sha512-SKKdA5RnvZr3pvFXkxtfsBVNgflRGa/bN1HbNi+1s0HNVYPuhB9DFC/CrKe2OoOfUXx7F7k2gg0Jg9gJYDy4rA==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.4.0",
+        "@docusaurus/types": "3.5.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2343,18 +2370,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
-      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.5.1.tgz",
+      "integrity": "sha512-aPmrMV5cDa2QUZ+kPVJID5O6r+ZuLFtHEyneVl9AgryL/9ECudhtpTUdmdnmapnWfUzSSgqYRZ1JtydGLheSzw==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
-        "cheerio": "^1.0.0-rc.12",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
+        "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2369,23 +2398,26 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
-      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.1.tgz",
+      "integrity": "sha512-DX+I3eVyXak9KqYXg8dgptomqz/O4twjydpLJT8ZSe9lsZ0Pa1ZNPwmftWYn160O3o6GGeUYzr13Y1Got3iXRQ==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2404,15 +2436,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
-      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.5.1.tgz",
+      "integrity": "sha512-V2PDVrO2vHYJ7uhrEHpfzg3TTuwfrgNC0pGhM5gXaMfCbdhKm7iwV0huGLcyIX5Peyh7EMP2e8GFccUzWFMYOg==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2426,13 +2459,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
-      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.5.1.tgz",
+      "integrity": "sha512-teFZamoECDiELwM1cx5OXd6dBpRtHarc7kWGL1iQozAkYcobZmqOWykBl4joMjSWUbJlx5v9/CVciykWbFNXjA==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2446,13 +2480,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
-      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.5.1.tgz",
+      "integrity": "sha512-5FUiYZQWPXTPucMzaOOM25R7IwIPvMKbiB0SNVGtxVsGyFyo5i5fzrkBQl4mkZd7uqmslEPzwYbC28ZeFnrxjg==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2464,13 +2499,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
-      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.1.tgz",
+      "integrity": "sha512-jxBtLBPMv9BJXPXrwJSs69qYcHP/evT1NkVza2yOai7wi5r3E1tVm0bAxdciWitpM0dgS/HDa30qXE7vA1NRDg==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2483,13 +2519,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
-      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.5.1.tgz",
+      "integrity": "sha512-W5WsKoRmb3lDmg2IBfmKsZDlQAkEx/dXuwr4bj7sSQdM8qd829Rsc4Gp5RddUrQdUz/W3Iocn7LayRM5aacJlA==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2501,19 +2538,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-pwa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-pwa/-/plugin-pwa-3.4.0.tgz",
-      "integrity": "sha512-HC5gK1lFhy0E8SbGgWRl49+5LycAi4C+0YvFRiQRkF6ryJCfXGVIPXtgdXuatCb9iAN40trad3byw73GOragZg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-pwa/-/plugin-pwa-3.5.1.tgz",
+      "integrity": "sha512-bdJYduNZSEVHUO3a/2/ADZePtdhZ2c7oxuVcf1IBMD8iFIL2Moe4ozM9l7jmUoaQC2vDhEEloT8EIp0kF6+Cqg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/preset-env": "^7.23.3",
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/theme-translations": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "babel-loader": "^9.1.3",
         "clsx": "^2.0.0",
         "core-js": "^3.31.1",
@@ -2535,16 +2573,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
-      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.1.tgz",
+      "integrity": "sha512-VXMGJM6uy4jx6HUsFs+kn8MujWGjN7S7p7PYUYSf1bmcFNlf+Qg5vDZtwBElHa2hapeH2AIj2b3QmTgmWeyOHw==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2558,23 +2597,24 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
-      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.5.1.tgz",
+      "integrity": "sha512-afDMZoNYxdloJ7qJJbd3Lmv9uYXKKsEAOtvnvu2945kqe1LUGIIwOo1nMAKgB9y21E5FEvWKnla0MvkMraumZA==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/plugin-debug": "3.4.0",
-        "@docusaurus/plugin-google-analytics": "3.4.0",
-        "@docusaurus/plugin-google-gtag": "3.4.0",
-        "@docusaurus/plugin-google-tag-manager": "3.4.0",
-        "@docusaurus/plugin-sitemap": "3.4.0",
-        "@docusaurus/theme-classic": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-search-algolia": "3.4.0",
-        "@docusaurus/types": "3.4.0"
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/plugin-content-blog": "3.5.1",
+        "@docusaurus/plugin-content-docs": "3.5.1",
+        "@docusaurus/plugin-content-pages": "3.5.1",
+        "@docusaurus/plugin-debug": "3.5.1",
+        "@docusaurus/plugin-google-analytics": "3.5.1",
+        "@docusaurus/plugin-google-gtag": "3.5.1",
+        "@docusaurus/plugin-google-tag-manager": "3.5.1",
+        "@docusaurus/plugin-sitemap": "3.5.1",
+        "@docusaurus/theme-classic": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/theme-search-algolia": "3.5.1",
+        "@docusaurus/types": "3.5.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2585,26 +2625,27 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
-      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.5.1.tgz",
+      "integrity": "sha512-k8rLMwHuTc3SqYekc20s1uZHjabt9yi6mt1RUjbkwmjsJlAB6zrtYvsB+ZxrhY5yeUD8DZm3h0qVvKbClHVCCA==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/plugin-content-blog": "3.5.1",
+        "@docusaurus/plugin-content-docs": "3.5.1",
+        "@docusaurus/plugin-content-pages": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/theme-translations": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
-        "infima": "0.2.0-alpha.43",
+        "infima": "0.2.0-alpha.44",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.26",
@@ -2624,17 +2665,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
-      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.5.1.tgz",
+      "integrity": "sha512-r34YDzSjggX+B+8W+mG2dVh1ps4JJRCiyq8E1LnZIKLU6F89I2KpAZpPQ2/njKsKhBRLtQ1x92HVkD0FZ3xjrg==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2648,20 +2687,22 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.4.0.tgz",
-      "integrity": "sha512-3w5QW0HEZ2O6x2w6lU3ZvOe1gNXP2HIoKDMJBil1VmLBc9PmpAG17VmfhI/p3L2etNmOiVs5GgniUqvn8AFEGQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.5.1.tgz",
+      "integrity": "sha512-yCYNMuRVcAUsn2Nods+SjYWsifAO76JXgsMHzb6ZFaVNfvXBWxX77ZdotsLAsA43apnPC4BMQ31Ux41dT155vg==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "mermaid": "^10.4.0",
         "tslib": "^2.6.0"
       },
@@ -2674,18 +2715,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
-      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.5.1.tgz",
+      "integrity": "sha512-IcUbgh9YcedANhpa0Q3+67WUKY8G7YkN/pZxVBEFjq3d2bniRKktPv41Nh/+AtGLSNJIcspZwEAs/r/mKSZGug==",
+      "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/plugin-content-docs": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/theme-translations": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2704,9 +2746,10 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
-      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.1.tgz",
+      "integrity": "sha512-fyzQOWrTm0+ZpTlS0/xHsIK4f+LA4qVFrq8rCzIHjxZRip/noYUOwF64lA95vcuw6qnOVBoNE/LyfbBvExnpcw==",
+      "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2716,9 +2759,10 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.1.tgz",
+      "integrity": "sha512-IXTGQBoXAGFliGF5Cn3F+gSGskgzAL8+4y6dDY1gcePA0r8WngHj8oovS1YPv+b9JOff32nv8YGGZITHOMXJsA==",
+      "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -2736,12 +2780,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
-      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.1.tgz",
+      "integrity": "sha512-/4QAvXyiQviz2FQ4ct5l1ckvDihIdjS8FsOExC0T+Y1UD38jgPbjTwRJXsDaRsDRCCrDAtXvlonxXw2kixcnXw==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
         "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2774,9 +2819,10 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
-      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.1.tgz",
+      "integrity": "sha512-374n6/IW34gHR65JMMN33XLFogTCsrGVPQDVbv2vG96EYHvYzE/plfcGV7xSbXB8yS1YHsxVfvNgVUGi973bfQ==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2793,13 +2839,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.1.tgz",
+      "integrity": "sha512-LZdQnqVVLStgTCn0rfvf4wuOQkjPbGtLXJIQ449em1wJeSFO7lfmn5VGUNLt+xKHvIPfN272EHG8BuvijCI0+A==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -3783,6 +3830,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
       "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4128,31 +4176,33 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.23.3.tgz",
-      "integrity": "sha512-Le/3YgNvjW9zxIQMRhUHuhiUjAlKY/zsdZpfq4dlLqg6mEm0nL6yk+7f2hDOtLpxsgE4jSzDmvHL7nXdBp5feg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.3",
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/cache-in-memory": "4.23.3",
-        "@algolia/client-account": "4.23.3",
-        "@algolia/client-analytics": "4.23.3",
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-personalization": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/logger-console": "4.23.3",
-        "@algolia/recommend": "4.23.3",
-        "@algolia/requester-browser-xhr": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/requester-node-http": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-account": "4.24.0",
+        "@algolia/client-analytics": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-personalization": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/recommend": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.21.0.tgz",
-      "integrity": "sha512-hjVOrL15I3Y3K8xG0icwG1/tWE+MocqBrhW6uVBWpU+/kVEMK0BnM2xdssj6mZM61eJ4iRxHR0djEI3ENOpR8w==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.3.tgz",
+      "integrity": "sha512-2eoEz8mG4KHE+DzfrBTrCmDPxVXv7aZZWPojAJFtARpxxMO6lkos1dJ+XDCXdPvq7q3tpYWRi6xXmVQikejtpA==",
+      "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -4234,7 +4284,8 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4312,9 +4363,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.19",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
       "funding": [
         {
           "type": "opencollective",
@@ -4329,12 +4380,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001599",
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "bin": {
@@ -4567,9 +4619,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4584,11 +4636,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4712,9 +4765,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001617",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
-      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
+      "version": "1.0.30001651",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
+      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4728,7 +4781,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -5534,6 +5588,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-6.1.2.tgz",
       "integrity": "sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==",
+      "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.19",
         "browserslist": "^4.23.0",
@@ -6569,9 +6624,10 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.763",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.763.tgz",
-      "integrity": "sha512-k4J8NrtJ9QrvHLRo8Q18OncqBCB7tIUyqxRcJnlonQ0ioHKYB988GcDFF3ZePmnb8eHEopDs/wPHR/iGAFgoUQ=="
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.6.tgz",
+      "integrity": "sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==",
+      "license": "ISC"
     },
     "node_modules/elkjs": {
       "version": "0.9.3",
@@ -7532,6 +7588,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       },
@@ -8609,9 +8666,10 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.43",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
-      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
+      "version": "0.2.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.44.tgz",
+      "integrity": "sha512-tuRkUSO/lB3rEhLJk25atwAjgLuzq070+pOW8XcvpHky/YbENnRRdPd85IBkyeTgttmOy5ah+yHYsK1HhUd4lQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -12432,9 +12490,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "license": "MIT"
     },
     "node_modules/non-layered-tidy-tree-layout": {
       "version": "2.0.2",
@@ -12453,6 +12512,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12884,9 +12944,10 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -13110,6 +13171,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-6.0.5.tgz",
       "integrity": "sha512-wHalBlRHkaNnNwfC8z+ppX57VhvS+HWgjW508esjdaEYr3Mx7Gnn2xA4R/CKf5+Z9S5qsqC+Uzh4ueENWwCVUA==",
+      "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.0.16"
       },
@@ -13145,6 +13207,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-6.0.3.tgz",
       "integrity": "sha512-1oIoAsODUs6IHQZkLQGO15uGEbK3EAl5wi9SS8hs45VgsxQfMnxvt+L+zIr7ifZFIH14cfAeVe2uCTa+SPRa3g==",
+      "license": "MIT",
       "dependencies": {
         "cssnano-utils": "^4.0.2",
         "postcss-value-parser": "^4.2.0"
@@ -13446,6 +13509,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-6.0.3.tgz",
       "integrity": "sha512-G3yCqZDpsNPoQgbDUy3T0E6hqOQ5xigUtBQyrmq3tn2GxlyiL0yyl7H+T8ulQR6kOcHJ9t7/9H4/R2tv8tJbMA==",
+      "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -13501,6 +13565,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-5.2.0.tgz",
       "integrity": "sha512-AZ5fDMLD8SldlAYlvi8NIqo0+Z8xnXU2ia0jxmuhxAU+Lqt9K+AlmLNJ/zWEnE9x+Zx3qL3+1K20ATgNOr3fAA==",
+      "license": "MIT",
       "dependencies": {
         "sort-css-media-queries": "2.2.0"
       },
@@ -13549,6 +13614,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-6.0.2.tgz",
       "integrity": "sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==",
+      "license": "MIT",
       "engines": {
         "node": "^14 || ^16 || >=18.0"
       },
@@ -13972,6 +14038,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.4.0.tgz",
       "integrity": "sha512-wh6F6uJyYAmQ4fK0e8dSQMEWuvTs2Wr3el3sLD9bambX1+pSWUVXIz1RFaoy3TI1mZ0FqdpKq9YgbgTTgyrmXA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       },
@@ -14730,9 +14797,10 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.14.0.tgz",
-      "integrity": "sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.16.2.tgz",
+      "integrity": "sha512-+KrS5rnYlyWgzoCNJGsNPw7Vv+47Y7Ze7KZ+/9Xls+5BUugEbU2yv1n9JsQOqv+MLKYfg3bxI5K6tYJxXZY8FA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/section-matter": {
@@ -15088,6 +15156,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
       "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -15105,7 +15174,8 @@
     "node_modules/sitemap/node_modules/@types/node": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
     },
     "node_modules/skin-tone": {
       "version": "2.0.0",
@@ -15154,6 +15224,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.2.0.tgz",
       "integrity": "sha512-0xtkGhWCC9MGt/EzgnvbbbKhqWjl1+/rncmhTh5qCpbYguXh6S/qwePfv/JQ8jePXXmqingylxoC49pCkSPIbA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6.3.0"
       }
@@ -16196,9 +16267,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
-      "integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16213,9 +16284,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.1.2",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   },
   "dependencies": {
     "@crowdin/cli": "^3.19.4",
-    "@docusaurus/core": "^3.4.0",
-    "@docusaurus/plugin-content-docs": "^3.4.0",
-    "@docusaurus/plugin-google-gtag": "^3.4.0",
-    "@docusaurus/plugin-google-tag-manager": "^3.4.0",
-    "@docusaurus/plugin-pwa": "^3.4.0",
-    "@docusaurus/preset-classic": "^3.4.0",
-    "@docusaurus/theme-mermaid": "^3.4.0",
+    "@docusaurus/core": "^3.5.1",
+    "@docusaurus/plugin-content-docs": "^3.5.1",
+    "@docusaurus/plugin-google-gtag": "^3.5.1",
+    "@docusaurus/plugin-google-tag-manager": "^3.5.1",
+    "@docusaurus/plugin-pwa": "^3.5.1",
+    "@docusaurus/preset-classic": "^3.5.1",
+    "@docusaurus/theme-mermaid": "^3.5.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-plugin-image-zoom": "^2.0.0",
@@ -32,8 +32,8 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.4.0",
-    "@docusaurus/types": "^3.4.0"
+    "@docusaurus/module-type-aliases": "^3.5.1",
+    "@docusaurus/types": "^3.5.1"
   },
   "browserslist": {
     "production": [

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import {useBlogPost} from '@docusaurus/theme-common/internal';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import EditMetaRow from '@theme/EditMetaRow';
 import TagsListInline from '@theme/TagsListInline';
@@ -34,6 +34,7 @@ export default function BlogPostItemFooter(): JSX.Element | null {
 
     return (
       <footer className="docusaurus-mt-lg">
+        {/* The following is commented out to not show tags in the footer since we want them to show in the header instead. */}
         {/* {tagsExists && (
           <div
             className={clsx(
@@ -64,6 +65,7 @@ export default function BlogPostItemFooter(): JSX.Element | null {
   else {
     return (
       <footer className="row docusaurus-mt-lg">
+        {/* The following is commented out to not show tags in the footer since we want them to show in the header instead. */}        
         {/* {tagsExists && (
           <div className={clsx('col', {'col--9': truncatedPost})}>
             <TagsListInline tags={tags} />
@@ -72,6 +74,10 @@ export default function BlogPostItemFooter(): JSX.Element | null {
         {truncatedPost && (
           <div
             className={clsx('col text--left')}>
+            {/* The above line was previously the following but since we're hiding tags in the footer, we need to adjust it. */}
+            {/* className={clsx('col text--right', {
+              'col--3': tagsExists,
+            })}> */}
             <ReadMoreLink blogPostTitle={title} to={metadata.permalink} />
           </div>
         )}

--- a/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import {usePluralForm, ThemeClassNames} from '@docusaurus/theme-common';
-import {
-  useBlogPost,
-  useDateTimeFormat,
-} from '@docusaurus/theme-common/internal';
+import {useDateTimeFormat} from '@docusaurus/theme-common/internal';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import type {Props} from '@theme/BlogPostItem/Header/Info';
 import TagsListInline from '@theme/TagsListInline';
 
@@ -54,8 +52,9 @@ export default function BlogPostItemHeaderInfo({
   className,
 }: Props): JSX.Element {
   const {metadata} = useBlogPost();
+  
+  {/* The following two lines were changed to show tags in the header instead of in the footer. */} 
   const {date, readingTime, tags} = metadata;
-
   const tagsExists = tags.length > 0;
 
   const dateTimeFormat = useDateTimeFormat({
@@ -70,6 +69,7 @@ export default function BlogPostItemHeaderInfo({
 
   return (
     <div className={clsx(styles.container, 'margin-vert--md', className)}>
+      {/* The following was added to show tags in the header instead of in the footer. */}
       {tagsExists && (
         <div
           className={clsx(

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDoc} from '@docusaurus/theme-common/internal';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import TagsListInline from '@theme/TagsListInline';
 
 import EditMetaRow from '@theme/EditMetaRow';
@@ -22,7 +22,7 @@ export default function DocItemFooter(): JSX.Element | null {
   return (
     <footer
       className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}>
-      {/* Commented out tags since we've added them to the top of docs. (See src/theme/DocVersionBadge/index.tsx) */}
+      {/* The following is commented out to not show tags in the footer since we want them to show in the header instead. */} 
       {/* {canDisplayTagsRow && (
         <div
           className={clsx(

--- a/src/theme/DocVersionBadge/index.tsx
+++ b/src/theme/DocVersionBadge/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDocsVersion, useDoc} from '@docusaurus/theme-common/internal';
+import {useDocsVersion, useDoc} from '@docusaurus/plugin-content-docs/client';
 import type {Props} from '@theme/DocVersionBadge';
 import TagsListInline from '@theme/TagsListInline';
 
@@ -10,11 +10,13 @@ export default function DocVersionBadge({
   className,
 }: Props): JSX.Element | null {
 
+  {/* The following was added to show tags in the header instead of in the footer. */}
   const {metadata} = useDoc();
   const {tags} = metadata;
 
-  const versionMetadata = useDocsVersion();
-  // if (versionMetadata.badge) {
+  {/* The following lines is commented out since my portfolio doesn't have versioned docs. */}
+  {/* const versionMetadata = useDocsVersion();
+  if (versionMetadata.badge) { */}
     return (
       <span
         className={clsx(
@@ -22,7 +24,7 @@ export default function DocVersionBadge({
           ThemeClassNames.docs.docVersionBadge,
           'badge badge--secondary',
         )}>
-        {/* The following is commented out since my personal portfolio doesn't have versioned docs. */}
+        {/* The following is commented out since my portfolio doesn't have versioned docs. */}
         {/* <Translate
           id="theme.docs.versionBadge.label"
           values={{versionLabel: versionMetadata.label}}>
@@ -39,6 +41,6 @@ export default function DocVersionBadge({
         </div>
       </span>
     );
-  //}
+  // }
   return null;
 }


### PR DESCRIPTION
## Description

This PR is to upgrade Docusaurus from 3.4.0 to 3.5.1. 

Some changes needed to be made because of changes in Docusaurus that broke functionality related to moving the tags from the bottom of pages to the top of pages.

> [!NOTE]
> 
> Docusaurus release notes:
> 
> - [3.5.0](https://docusaurus.io/changelog/3.5.0)
> - [3.5.1](https://docusaurus.io/changelog/3.5.1)

## Related issues and/or PRs

N/A

## Changes made

- Changed the version for Docusaurus from 3.4.0 to 3.5.1.
- Re-swizzled the `BlogPostItem/Header`, `BlogPostItem/Footer`, `DocItemFooter`, and `DocVersionBadge` components
  - Revised these components to fit the previous changes to make tags appear at the top of pages instead of in the footer.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
