### PR TITLE
Add social links to author card that appears on blog posts

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -3,3 +3,9 @@ josh-wong:
   title: Content Strategist & Technical Writer
   url: https://github.com/josh-wong
   image_url: https://github.com/josh-wong.png
+  socials:
+    github: josh-wong
+    linkedin: wongjoshua
+    x: 080f53
+    
+    


### PR DESCRIPTION
## Description

This PR adds social links to my author card that appears on blog posts. This feature was implemented in [Docusaurus 3.5.0](https://docusaurus.io/blog/releases/3.5#blog-social-icons).

## Related issues and/or PRs

N/A

## Changes made

- Added social links for GitHub, LinkedIn, and Twitter to my `authors.yml` file.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
