### PR TITLE
Add "Download" button value; change button value on existing page

### DIFF
--- a/i18n/versioned_docs/en-us/code.json
+++ b/i18n/versioned_docs/en-us/code.json
@@ -2,6 +2,9 @@
   "button.readMore": {
     "message": "Read more"
   },
+  "button.download": {
+    "message": "Download"
+  },
   "professional.XXX.description": {
     "message": "PLACEHOLDER"
   },

--- a/src/components/Cards/buttons.tsx
+++ b/src/components/Cards/buttons.tsx
@@ -54,7 +54,7 @@ function Card({ name, /*image,*/ url, /*description*/ }: Props) {
         <div className="card__footer">
           <div className="button-group button-group--block">
             <Link className="button button--secondary" to={url.page}>
-              <Translate id="button.readMore">Download</Translate>
+              <Translate id="button.download"></Translate>
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Description

This PR adds a "Download" button value and changes the value of a button in a component that mistakenly had the download button showing as "Read more."

## Related issues and/or PRs

N/A

## Changes made

- Added `button.download` to the list of available button values.
- Changed the button in the card component used on the passGen overview page from `button.readMore` to `button.download`.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
