### PR TITLE
Upgrade Docusaurus from 3.5.1 to 3.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@crowdin/cli": "^3.19.4",
-        "@docusaurus/core": "^3.5.1",
-        "@docusaurus/plugin-content-docs": "^3.5.1",
-        "@docusaurus/plugin-google-gtag": "^3.5.1",
-        "@docusaurus/plugin-google-tag-manager": "^3.5.1",
-        "@docusaurus/plugin-pwa": "^3.5.1",
-        "@docusaurus/preset-classic": "^3.5.1",
-        "@docusaurus/theme-mermaid": "^3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/plugin-google-gtag": "3.5.2",
+        "@docusaurus/plugin-google-tag-manager": "3.5.2",
+        "@docusaurus/plugin-pwa": "3.5.2",
+        "@docusaurus/preset-classic": "3.5.2",
+        "@docusaurus/theme-mermaid": "3.5.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "docusaurus-plugin-image-zoom": "^2.0.0",
@@ -25,8 +25,8 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.5.1",
-        "@docusaurus/types": "^3.5.1"
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/types": "3.5.2"
       },
       "engines": {
         "node": ">=18.0"
@@ -112,6 +112,27 @@
         "@algolia/transporter": "4.24.0"
       }
     },
+    "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
     "node_modules/@algolia/client-analytics": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
@@ -124,7 +145,7 @@
         "@algolia/transporter": "4.24.0"
       }
     },
-    "node_modules/@algolia/client-common": {
+    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
       "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
@@ -132,6 +153,27 @@
       "dependencies": {
         "@algolia/requester-common": "4.24.0",
         "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.0.0.tgz",
+      "integrity": "sha512-6N5Qygv/Z/B+rPufnPDLNWgsMf1uubMU7iS52xLcQSLiGlTS4f9eLUrmNXSzHccP33uoFi6xN9craN1sZi5MPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
@@ -145,15 +187,29 @@
         "@algolia/transporter": "4.24.0"
       }
     },
-    "node_modules/@algolia/client-search": {
+    "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
       "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.24.0",
         "@algolia/requester-common": "4.24.0",
         "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.0.0.tgz",
+      "integrity": "sha512-QdDYMzoxYZ3axzBy6CHe+M+NlOGvHEFTa2actchGnp25Uu0N6lyVNivT7nph+P1XoxgAD08cWbeJD3wWQXnpng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.0.0",
+        "@algolia/requester-browser-xhr": "5.0.0",
+        "@algolia/requester-node-http": "5.0.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -196,13 +252,56 @@
         "@algolia/transporter": "4.24.0"
       }
     },
-    "node_modules/@algolia/requester-browser-xhr": {
+    "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
       "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.0.0.tgz",
+      "integrity": "sha512-oOoQhSpg/RGiGHjn/cqtYpHBkkd+5M/DCi1jmfW+ZOvLVx21QVt6PbWIJoKJF85moNFo4UG9pMBU35R1MaxUKQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.0.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-common": {
@@ -212,12 +311,16 @@
       "license": "MIT"
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.0.0.tgz",
+      "integrity": "sha512-FwCdugzpnW0wxbgWPauAz5vhmWGQnjZa5DCl9PBbIoDNEy/NIV8DmiL9CEA+LljQdDidG0l0ijojcTNaRRtPvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@algolia/requester-common": "4.24.0"
+        "@algolia/client-common": "5.0.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/transporter": {
@@ -2198,9 +2301,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-N3+9IbGI2jbkiRc6ZbEnU9dC02nHQXi8ivM1VJldkPQyP7WlyHXS+NDhmL3rwaYOMbGH96X2LcKigCKg7pEEqg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
+      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.3",
@@ -2213,12 +2316,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.1",
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/mdx-loader": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/cssnano-preset": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2279,14 +2382,15 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@mdx-js/react": "^3.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.1.tgz",
-      "integrity": "sha512-mvtWPLWePlm+4doepxMUT5ynsJQ3CgPtDdbaQh9wm3iAE/7OATBpSgLlfz5N+YtxI5bjIErjbkH8yzISP+S65g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
+      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -2299,9 +2403,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.1.tgz",
-      "integrity": "sha512-B36a88CEHCtxIylAV1HNuiiISpoKBqm0UxA6a/JwtHX++Dxb7LNDSGs8ELBlQsZN0OG2tX3tBsCWyaLPwYorkQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
+      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -2312,14 +2416,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.1.tgz",
-      "integrity": "sha512-D6Ea2dt32xhoqH+1EuHLGDVSX2HLFiR4QpI0GTU46qOu2hb2ChpQENIUZ2inOsdGFunNa0fCnDG3qn7Kdbzq1A==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
+      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2351,12 +2455,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.1.tgz",
-      "integrity": "sha512-SKKdA5RnvZr3pvFXkxtfsBVNgflRGa/bN1HbNi+1s0HNVYPuhB9DFC/CrKe2OoOfUXx7F7k2gg0Jg9gJYDy4rA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz",
+      "integrity": "sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.5.1",
+        "@docusaurus/types": "3.5.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2370,19 +2474,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.5.1.tgz",
-      "integrity": "sha512-aPmrMV5cDa2QUZ+kPVJID5O6r+ZuLFtHEyneVl9AgryL/9ECudhtpTUdmdnmapnWfUzSSgqYRZ1JtydGLheSzw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.5.2.tgz",
+      "integrity": "sha512-R7ghWnMvjSf+aeNDH0K4fjyQnt5L0KzUEnUhmf1e3jZrv3wogeytZNN6n7X8yHcMsuZHPOrctQhXWnmxu+IRRg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/mdx-loader": "3.5.1",
-        "@docusaurus/theme-common": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2404,20 +2508,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.1.tgz",
-      "integrity": "sha512-DX+I3eVyXak9KqYXg8dgptomqz/O4twjydpLJT8ZSe9lsZ0Pa1ZNPwmftWYn160O3o6GGeUYzr13Y1Got3iXRQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.2.tgz",
+      "integrity": "sha512-Bt+OXn/CPtVqM3Di44vHjE7rPCEsRCB/DMo2qoOuozB9f7+lsdrHvD0QCHdBs0uhz6deYJDppAr2VgqybKPlVQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/mdx-loader": "3.5.1",
-        "@docusaurus/module-type-aliases": "3.5.1",
-        "@docusaurus/theme-common": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2436,16 +2540,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.5.1.tgz",
-      "integrity": "sha512-V2PDVrO2vHYJ7uhrEHpfzg3TTuwfrgNC0pGhM5gXaMfCbdhKm7iwV0huGLcyIX5Peyh7EMP2e8GFccUzWFMYOg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.5.2.tgz",
+      "integrity": "sha512-WzhHjNpoQAUz/ueO10cnundRz+VUtkjFhhaQ9jApyv1a46FPURO4cef89pyNIOMny1fjDz/NUN2z6Yi+5WUrCw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/mdx-loader": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2459,14 +2563,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.5.1.tgz",
-      "integrity": "sha512-teFZamoECDiELwM1cx5OXd6dBpRtHarc7kWGL1iQozAkYcobZmqOWykBl4joMjSWUbJlx5v9/CVciykWbFNXjA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.5.2.tgz",
+      "integrity": "sha512-kBK6GlN0itCkrmHuCS6aX1wmoWc5wpd5KJlqQ1FyrF0cLDnvsYSnh7+ftdwzt7G6lGBho8lrVwkkL9/iQvaSOA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2480,14 +2584,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.5.1.tgz",
-      "integrity": "sha512-5FUiYZQWPXTPucMzaOOM25R7IwIPvMKbiB0SNVGtxVsGyFyo5i5fzrkBQl4mkZd7uqmslEPzwYbC28ZeFnrxjg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.5.2.tgz",
+      "integrity": "sha512-rjEkJH/tJ8OXRE9bwhV2mb/WP93V441rD6XnM6MIluu7rk8qg38iSxS43ga2V2Q/2ib53PcqbDEJDG/yWQRJhQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2499,14 +2603,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.1.tgz",
-      "integrity": "sha512-jxBtLBPMv9BJXPXrwJSs69qYcHP/evT1NkVza2yOai7wi5r3E1tVm0bAxdciWitpM0dgS/HDa30qXE7vA1NRDg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.2.tgz",
+      "integrity": "sha512-lm8XL3xLkTPHFKKjLjEEAHUrW0SZBSHBE1I+i/tmYMBsjCcUB5UJ52geS5PSiOCFVR74tbPGcPHEV/gaaxFeSA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2519,14 +2623,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.5.1.tgz",
-      "integrity": "sha512-W5WsKoRmb3lDmg2IBfmKsZDlQAkEx/dXuwr4bj7sSQdM8qd829Rsc4Gp5RddUrQdUz/W3Iocn7LayRM5aacJlA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.5.2.tgz",
+      "integrity": "sha512-QkpX68PMOMu10Mvgvr5CfZAzZQFx8WLlOiUQ/Qmmcl6mjGK6H21WLT5x7xDmcpCoKA/3CegsqIqBR+nA137lQg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2538,20 +2642,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-pwa": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-pwa/-/plugin-pwa-3.5.1.tgz",
-      "integrity": "sha512-bdJYduNZSEVHUO3a/2/ADZePtdhZ2c7oxuVcf1IBMD8iFIL2Moe4ozM9l7jmUoaQC2vDhEEloT8EIp0kF6+Cqg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-pwa/-/plugin-pwa-3.5.2.tgz",
+      "integrity": "sha512-FCwE+C04PgoCpOnDecr4qnVJdwrOphOVRkeXSUvL6dEHjxfuB+WpSxFA6ASVSxPnFwrBhwt8UQ3vYQgxYNSstQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/preset-env": "^7.23.3",
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/theme-common": "3.5.1",
-        "@docusaurus/theme-translations": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-translations": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "babel-loader": "^9.1.3",
         "clsx": "^2.0.0",
         "core-js": "^3.31.1",
@@ -2573,17 +2677,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.1.tgz",
-      "integrity": "sha512-VXMGJM6uy4jx6HUsFs+kn8MujWGjN7S7p7PYUYSf1bmcFNlf+Qg5vDZtwBElHa2hapeH2AIj2b3QmTgmWeyOHw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.2.tgz",
+      "integrity": "sha512-DnlqYyRAdQ4NHY28TfHuVk414ft2uruP4QWCH//jzpHjqvKyXjj2fmDtI8RPUBh9K8iZKFMHRnLtzJKySPWvFA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2597,24 +2701,24 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.5.1.tgz",
-      "integrity": "sha512-afDMZoNYxdloJ7qJJbd3Lmv9uYXKKsEAOtvnvu2945kqe1LUGIIwOo1nMAKgB9y21E5FEvWKnla0MvkMraumZA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.5.2.tgz",
+      "integrity": "sha512-3ihfXQ95aOHiLB5uCu+9PRy2gZCeSZoDcqpnDvf3B+sTrMvMTr8qRUzBvWkoIqc82yG5prCboRjk1SVILKx6sg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/plugin-content-blog": "3.5.1",
-        "@docusaurus/plugin-content-docs": "3.5.1",
-        "@docusaurus/plugin-content-pages": "3.5.1",
-        "@docusaurus/plugin-debug": "3.5.1",
-        "@docusaurus/plugin-google-analytics": "3.5.1",
-        "@docusaurus/plugin-google-gtag": "3.5.1",
-        "@docusaurus/plugin-google-tag-manager": "3.5.1",
-        "@docusaurus/plugin-sitemap": "3.5.1",
-        "@docusaurus/theme-classic": "3.5.1",
-        "@docusaurus/theme-common": "3.5.1",
-        "@docusaurus/theme-search-algolia": "3.5.1",
-        "@docusaurus/types": "3.5.1"
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/plugin-content-blog": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/plugin-content-pages": "3.5.2",
+        "@docusaurus/plugin-debug": "3.5.2",
+        "@docusaurus/plugin-google-analytics": "3.5.2",
+        "@docusaurus/plugin-google-gtag": "3.5.2",
+        "@docusaurus/plugin-google-tag-manager": "3.5.2",
+        "@docusaurus/plugin-sitemap": "3.5.2",
+        "@docusaurus/theme-classic": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-search-algolia": "3.5.2",
+        "@docusaurus/types": "3.5.2"
       },
       "engines": {
         "node": ">=18.0"
@@ -2625,23 +2729,23 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.5.1.tgz",
-      "integrity": "sha512-k8rLMwHuTc3SqYekc20s1uZHjabt9yi6mt1RUjbkwmjsJlAB6zrtYvsB+ZxrhY5yeUD8DZm3h0qVvKbClHVCCA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.5.2.tgz",
+      "integrity": "sha512-XRpinSix3NBv95Rk7xeMF9k4safMkwnpSgThn0UNQNumKvmcIYjfkwfh2BhwYh/BxMXQHJ/PdmNh22TQFpIaYg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/mdx-loader": "3.5.1",
-        "@docusaurus/module-type-aliases": "3.5.1",
-        "@docusaurus/plugin-content-blog": "3.5.1",
-        "@docusaurus/plugin-content-docs": "3.5.1",
-        "@docusaurus/plugin-content-pages": "3.5.1",
-        "@docusaurus/theme-common": "3.5.1",
-        "@docusaurus/theme-translations": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/plugin-content-blog": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/plugin-content-pages": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-translations": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2665,15 +2769,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.5.1.tgz",
-      "integrity": "sha512-r34YDzSjggX+B+8W+mG2dVh1ps4JJRCiyq8E1LnZIKLU6F89I2KpAZpPQ2/njKsKhBRLtQ1x92HVkD0FZ3xjrg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.5.2.tgz",
+      "integrity": "sha512-QXqlm9S6x9Ibwjs7I2yEDgsCocp708DrCrgHgKwg2n2AY0YQ6IjU0gAK35lHRLOvAoJUfCKpQAwUykB0R7+Eew==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.5.1",
-        "@docusaurus/module-type-aliases": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2693,16 +2797,16 @@
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.5.1.tgz",
-      "integrity": "sha512-yCYNMuRVcAUsn2Nods+SjYWsifAO76JXgsMHzb6ZFaVNfvXBWxX77ZdotsLAsA43apnPC4BMQ31Ux41dT155vg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.5.2.tgz",
+      "integrity": "sha512-7vWCnIe/KoyTN1Dc55FIyqO5hJ3YaV08Mr63Zej0L0mX1iGzt+qKSmeVUAJ9/aOalUhF0typV0RmNUSy5FAmCg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/module-type-aliases": "3.5.1",
-        "@docusaurus/theme-common": "3.5.1",
-        "@docusaurus/types": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "mermaid": "^10.4.0",
         "tslib": "^2.6.0"
       },
@@ -2715,19 +2819,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.5.1.tgz",
-      "integrity": "sha512-IcUbgh9YcedANhpa0Q3+67WUKY8G7YkN/pZxVBEFjq3d2bniRKktPv41Nh/+AtGLSNJIcspZwEAs/r/mKSZGug==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.5.2.tgz",
+      "integrity": "sha512-qW53kp3VzMnEqZGjakaV90sst3iN1o32PH+nawv1uepROO8aEGxptcq2R5rsv7aBShSRbZwIobdvSYKsZ5pqvA==",
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/plugin-content-docs": "3.5.1",
-        "@docusaurus/theme-common": "3.5.1",
-        "@docusaurus/theme-translations": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-validation": "3.5.1",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-translations": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2746,9 +2850,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.1.tgz",
-      "integrity": "sha512-fyzQOWrTm0+ZpTlS0/xHsIK4f+LA4qVFrq8rCzIHjxZRip/noYUOwF64lA95vcuw6qnOVBoNE/LyfbBvExnpcw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.2.tgz",
+      "integrity": "sha512-GPZLcu4aT1EmqSTmbdpVrDENGR2yObFEX8ssEFYTCiAIVc0EihNSdOIBTazUvgNqwvnoU1A8vIs1xyzc3LITTw==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -2759,9 +2863,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.1.tgz",
-      "integrity": "sha512-IXTGQBoXAGFliGF5Cn3F+gSGskgzAL8+4y6dDY1gcePA0r8WngHj8oovS1YPv+b9JOff32nv8YGGZITHOMXJsA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
+      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -2780,13 +2884,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.1.tgz",
-      "integrity": "sha512-/4QAvXyiQviz2FQ4ct5l1ckvDihIdjS8FsOExC0T+Y1UD38jgPbjTwRJXsDaRsDRCCrDAtXvlonxXw2kixcnXw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
+      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2819,9 +2923,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.1.tgz",
-      "integrity": "sha512-374n6/IW34gHR65JMMN33XLFogTCsrGVPQDVbv2vG96EYHvYzE/plfcGV7xSbXB8yS1YHsxVfvNgVUGi973bfQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
+      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.0"
@@ -2839,14 +2943,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.1.tgz",
-      "integrity": "sha512-LZdQnqVVLStgTCn0rfvf4wuOQkjPbGtLXJIQ449em1wJeSFO7lfmn5VGUNLt+xKHvIPfN272EHG8BuvijCI0+A==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
+      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.5.1",
-        "@docusaurus/utils": "3.5.1",
-        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4208,6 +4312,45 @@
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 6"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/ansi-align": {
@@ -14797,9 +14940,9 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.16.2.tgz",
-      "integrity": "sha512-+KrS5rnYlyWgzoCNJGsNPw7Vv+47Y7Ze7KZ+/9Xls+5BUugEbU2yv1n9JsQOqv+MLKYfg3bxI5K6tYJxXZY8FA==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.16.3.tgz",
+      "integrity": "sha512-hSHy/s4Zk2xibhj9XTCACB+1PqS+CaJxepGNBhKc/OsHRpqvHAUAm5+uZ6kJJbGXn0pb3XqekHjg6JAqPExzqg==",
       "license": "MIT",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   },
   "dependencies": {
     "@crowdin/cli": "^3.19.4",
-    "@docusaurus/core": "^3.5.1",
-    "@docusaurus/plugin-content-docs": "^3.5.1",
-    "@docusaurus/plugin-google-gtag": "^3.5.1",
-    "@docusaurus/plugin-google-tag-manager": "^3.5.1",
-    "@docusaurus/plugin-pwa": "^3.5.1",
-    "@docusaurus/preset-classic": "^3.5.1",
-    "@docusaurus/theme-mermaid": "^3.5.1",
+    "@docusaurus/core": "3.5.2",
+    "@docusaurus/plugin-content-docs": "3.5.2",
+    "@docusaurus/plugin-google-gtag": "3.5.2",
+    "@docusaurus/plugin-google-tag-manager": "3.5.2",
+    "@docusaurus/plugin-pwa": "3.5.2",
+    "@docusaurus/preset-classic": "3.5.2",
+    "@docusaurus/theme-mermaid": "3.5.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-plugin-image-zoom": "^2.0.0",
@@ -32,8 +32,8 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.5.1",
-    "@docusaurus/types": "^3.5.1"
+    "@docusaurus/module-type-aliases": "3.5.2",
+    "@docusaurus/types": "3.5.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Description

This PR is to upgrade Docusaurus from 3.5.1 to 3.5.2.

> [!NOTE]
> 
> For details about the release, see [Docusaurus 3.5.2 release notes](https://github.com/facebook/docusaurus/releases/tag/v3.5.2).
>
> This release includes my first PR contribution to Docusaurus (https://github.com/facebook/docusaurus/pull/10390). 😄🦖🚀

## Related issues and/or PRs

N/A

## Changes made

- Changed the version for Docusaurus from 3.5.1 to 3.5.2.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
