### PR TITLE
Change PWA theme color

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,7 +120,7 @@ const config = {
           {
             tagName: 'meta',
             name: 'theme-color',
-            content: '#fff',
+            content: '#080f53',
           },
           {
             tagName: 'meta',
@@ -130,7 +130,7 @@ const config = {
           {
             tagName: 'meta',
             name: 'apple-mobile-web-app-status-bar-style',
-            content: '#000',
+            content: '#080f53',
           },
           {
             tagName: 'link',
@@ -141,7 +141,7 @@ const config = {
             tagName: 'link',
             rel: 'mask-icon',
             href: '/img/favicon.svg',
-            color: 'rgb(8, 15, 83)',
+            color: '#080f53',
           },
           {
             tagName: 'meta',
@@ -151,7 +151,7 @@ const config = {
           {
             tagName: 'meta',
             name: 'msapplication-TileColor',
-            content: '#000',
+            content: '#080f53',
           },
         ],
       },


### PR DESCRIPTION
## Description

This PR changes the theme color used in the progressive web app (PWA). The theme color should be the same as the main color used for this site. If the theme is white, it looks a little odd, especially when users visit the site in dark mode.

## Related issues and/or PRs

N/A

## Changes made

- Changed the PWA theme color from `#fff` to `#080f53`.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.  `N/A`
- [x] I have updated the documentation to reflect the changes.  `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.  `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.  `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.  `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
