### PR TITLE
Add workflow to auto-create PRs from docs in `baird-beer-quadrants` repository

### DIFF
--- a/.github/workflows/auto-create-pr-baird-beer-quadrants.yml
+++ b/.github/workflows/auto-create-pr-baird-beer-quadrants.yml
@@ -1,0 +1,38 @@
+# This workflow auto-creates PRs for docs that have been updated in my "baird-beer-quadrants" repository.
+name: ✨ Auto-create PR - baird-beer-quadrants docs
+
+on:
+  push:
+    branches:
+      - baird-beer-quadrants/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs sync - `baird-beer-quadrants`',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to docs in the [josh-wong/baird-beer-quadrants](https://github.com/josh-wong/baird-beer-quadrants) repo to this repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'triage']
+            });


### PR DESCRIPTION
## Description

This PR adds a workflow that auto-create PRs when docs from my [baird-beer-quadrants](https://github.com/josh-wong/baird-beer-quadrants) repository have been updated.

## Related issues and/or PRs

Created a similar PR in #25.

## Changes made

- Created a workflow to sync updated docs from the [baird-beer-quadrants](https://github.com/josh-wong/baird-beer-quadrants) source repository to this repository.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A
- [x] I have updated the documentation to reflect the changes. `N/A
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A
- [x] My changes generate no new warnings.
