### PR TITLE
Add docs for Baird Brewing beer quadrants to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -43,6 +43,17 @@ const sidebars = {
       items: [
         {
           type: 'category',
+          label: 'Baird Brewing beer quadrants',
+          items: [
+            'personal/baird-beer-quadrants/overview',
+            'personal/baird-beer-quadrants/beers-year-round',
+            'personal/baird-beer-quadrants/beers-monthly-style-series',
+            'personal/baird-beer-quadrants/beers-fruitful-life-series',
+            'personal/baird-beer-quadrants/beers-taproom-exclusive',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Bitcoin Cash Node on Raspberry Pi',
           items: [
             'personal/bitcoin-cash-node-on-raspberry-pi/overview',


### PR DESCRIPTION
## Description

This PR adds new documentation for the [Baird Brewing beer profile quadrants](https://github.com/josh-wong/baird-beer-quadrants) to the sidebar navigation.

## Related issues and/or PRs

- https://github.com/josh-wong/baird-beer-quadrants/pull/1

## Changes made

- Added new documentation for the Baird Brewing beer profile quadrants to the sidebar navigation in my personal portfolio.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
