### PR TITLE
Add Baird beer quadrant card; add emojis to titles

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -43,7 +43,7 @@ const sidebars = {
       items: [
         {
           type: 'category',
-          label: 'Baird Brewing beer quadrants',
+          label: 'Baird beer profile quadrants🍻',
           items: [
             'personal/baird-beer-quadrants/overview',
             'personal/baird-beer-quadrants/beers-year-round',
@@ -54,7 +54,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Bitcoin Cash Node on Raspberry Pi',
+          label: 'Bitcoin Cash Node on Raspberry Pi🪙',
           items: [
             'personal/bitcoin-cash-node-on-raspberry-pi/overview',
             {
@@ -84,7 +84,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'passGen',
+          label: 'passGen🔐',
           items: [
             'personal/passgen/overview',
             'personal/passgen/generating-passwords',
@@ -95,7 +95,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Microsoft Zune device and software setup',
+          label: 'Microsoft Zune device and software setup🎵',
           items: [
             'personal/zune-software-setup/overview',
             'personal/zune-software-setup/getting-started',
@@ -108,7 +108,7 @@ const sidebars = {
         },
         {
           type: 'link',
-          label: 'Signal sticker pack - "Why Bitcoin Cash?"',
+          label: 'Signal sticker pack - "Why Bitcoin Cash?"🎁',
           href: 'https://signal.art/addstickers/#pack_id=183a3ca8d7ccdcdb8fa7728b17453fbc&pack_key=e9ac42b0e7276edd92d293321d2e51cca64e5744bad567fd9579b51abb78773d',
         },
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -84,17 +84,6 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'passGen🔐',
-          items: [
-            'personal/passgen/overview',
-            'personal/passgen/generating-passwords',
-            'personal/passgen/updating-the-app',
-            'personal/passgen/uninstalling',
-            'personal/passgen/references',
-          ],
-        },
-        {
-          type: 'category',
           label: 'Microsoft Zune device and software setup🎵',
           items: [
             'personal/zune-software-setup/overview',
@@ -104,6 +93,17 @@ const sidebars = {
             'personal/zune-software-setup/adding-apps-and-games',
             'personal/zune-software-setup/conclusion',
             'personal/zune-software-setup/references',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'passGen🔐',
+          items: [
+            'personal/passgen/overview',
+            'personal/passgen/generating-passwords',
+            'personal/passgen/updating-the-app',
+            'personal/passgen/uninstalling',
+            'personal/passgen/references',
           ],
         },
         {

--- a/src/components/Cards/projects.tsx
+++ b/src/components/Cards/projects.tsx
@@ -65,7 +65,19 @@ const CardsProfessionalProjects = [
 
 const CardsPersonalProjects = [
   {
-    name: 'Bitcoin Cash Node on a Raspberry Pi',
+    name: 'Baird Brewing beer profile quadrants🍻',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'personal/baird-beer-quadrants/overview',
+    },
+    description: (
+      <Translate id="personal.bairdBeerQuadrants.description">
+        Baird Brewing beer flavor profiles in Mermaid-based quadrants
+      </Translate>
+    ),
+  },
+  {
+    name: 'Bitcoin Cash Node on a Raspberry Pi🪙',
     // image: '<LINK_TO>.png',
     url: {
       page: 'personal/bitcoin-cash-node-on-raspberry-pi/overview',
@@ -77,7 +89,7 @@ const CardsPersonalProjects = [
     ),
   },
   {
-    name: 'Microsoft Zune device and software setup',
+    name: 'Microsoft Zune device and software setup🎵',
     // image: '<LINK_TO>.png',
     url: {
       page: 'personal/zune-software-setup/overview',
@@ -89,7 +101,7 @@ const CardsPersonalProjects = [
     ),
   },
   {
-    name: 'passGen',
+    name: 'passGen🔐',
     // image: '<LINK_TO>.png',
     url: {
       page: 'personal/passgen/overview',
@@ -101,7 +113,7 @@ const CardsPersonalProjects = [
     ),
   },
   {
-    name: 'Signal sticker pack - "Why Bitcoin Cash?"',
+    name: 'Signal sticker pack - "Why Bitcoin Cash?"🎁',
     // image: '<LINK_TO>.png',
     url: {
       page: 'https://signal.art/addstickers/#pack_id=183a3ca8d7ccdcdb8fa7728b17453fbc&pack_key=e9ac42b0e7276edd92d293321d2e51cca64e5744bad567fd9579b51abb78773d',

--- a/src/components/Cards/projects.tsx
+++ b/src/components/Cards/projects.tsx
@@ -65,7 +65,7 @@ const CardsProfessionalProjects = [
 
 const CardsPersonalProjects = [
   {
-    name: 'Baird beer profile quadrants',
+    name: 'Baird beer profile quadrants🍻',
     // image: '<LINK_TO>.png',
     url: {
       page: 'personal/baird-beer-quadrants/overview',
@@ -77,7 +77,7 @@ const CardsPersonalProjects = [
     ),
   },
   {
-    name: 'Bitcoin Cash Node on a Raspberry Pi',
+    name: 'Bitcoin Cash Node on a Raspberry Pi🪙',
     // image: '<LINK_TO>.png',
     url: {
       page: 'personal/bitcoin-cash-node-on-raspberry-pi/overview',
@@ -89,7 +89,7 @@ const CardsPersonalProjects = [
     ),
   },
   {
-    name: 'Microsoft Zune device and software setup',
+    name: 'Microsoft Zune device and software setup🎵',
     // image: '<LINK_TO>.png',
     url: {
       page: 'personal/zune-software-setup/overview',
@@ -101,7 +101,7 @@ const CardsPersonalProjects = [
     ),
   },
   {
-    name: 'passGen',
+    name: 'passGen🔐',
     // image: '<LINK_TO>.png',
     url: {
       page: 'personal/passgen/overview',
@@ -113,7 +113,7 @@ const CardsPersonalProjects = [
     ),
   },
   {
-    name: 'Signal sticker pack - "Why Bitcoin Cash?"',
+    name: 'Signal sticker pack - "Why Bitcoin Cash?"🎁',
     // image: '<LINK_TO>.png',
     url: {
       page: 'https://signal.art/addstickers/#pack_id=183a3ca8d7ccdcdb8fa7728b17453fbc&pack_key=e9ac42b0e7276edd92d293321d2e51cca64e5744bad567fd9579b51abb78773d',

--- a/src/components/Cards/projects.tsx
+++ b/src/components/Cards/projects.tsx
@@ -65,6 +65,18 @@ const CardsProfessionalProjects = [
 
 const CardsPersonalProjects = [
   {
+    name: 'Baird beer profile quadrants',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'personal/baird-beer-quadrants/overview',
+    },
+    description: (
+      <Translate id="personal.bairdBeerQuadrants.description">
+        Baird beer flavor profiles in Mermaid-based quadrants
+      </Translate>
+    ),
+  },
+  {
     name: 'Bitcoin Cash Node on a Raspberry Pi',
     // image: '<LINK_TO>.png',
     url: {


### PR DESCRIPTION
## Description

This PR adds a Baird beer flavor profile card to the personal portfolio cards and adds emojis to titles in the personal portfolio cards.

## Related issues and/or PRs

- https://github.com/josh-wong/josh-wong.github.io/pull/78

## Changes made

- Added a Baird beer flavor profile card to the personal portfolio cards.
- Added emojis to titles in the personal portfolio cards.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
