### PR TITLE
Fix label color of X-axis and Y-axis Mermaid quadrants in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -178,7 +178,7 @@ html[data-theme="dark"] .navbar-sidebar .header-rss-link {
   filter: invert(0%);
 }
 
-/* Better Stack status icon*/
+/* Better Stack status icon */
 .header-better-stack-icon::before {
   display: block;
   background-image: url("/img/better-stack-logo.svg");
@@ -203,4 +203,9 @@ html[data-theme="dark"] .header-better-stack-icon::before {
 
 html[data-theme="dark"] .navbar-sidebar .header-better-stack-icon {
   filter: invert(0%);
+}
+
+/* Mermaid quadrant label text color */
+html[data-theme="dark"] g[class^='label'] text {
+  fill: #e3e3e3;
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the label color for text in the X-axis and the Y-axis of Mermaid quadrants were dark gray in dark mode. Since the background is also dark gray, the labels were difficult to see.

## Related issues and/or PRs

N/A

## Changes made

- Added a custom style for the label color of Mermaid quadrants when in dark mode.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
