### PR TITLE
Update downloadable version of passGen to v3.4

### DIFF
--- a/src/components/Cards/buttons.tsx
+++ b/src/components/Cards/buttons.tsx
@@ -14,10 +14,10 @@ import Link from '@docusaurus/Link';
 
 const CardsPassGen = [
   {
-    name: 'passGen v3.2',
+    name: 'passGen v3.4',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'https://github.com/josh-wong/passGen/releases/download/v3.2.0/passGen_installer.exe',
+      page: 'https://github.com/josh-wong/passGen/releases/download/v3.4.0/passGen_installer.exe',
     },
     description: (
       <Translate id="buttons.passgenDownload.description">


### PR DESCRIPTION
## Description

This PR updates the downloadable version of passGen to v3.4.

## Related issues and/or PRs

- **Release:** https://github.com/josh-wong/passGen/releases/tag/v3.4.0

## Changes made

- Updated the component that contains the button for the downloadable link.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
