### PR TITLE
Add announcement bar about passGen v3.4 release

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -170,6 +170,14 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      announcementBar: {
+        id: 'announcement_bar',
+        content:
+          '<a href="https://www.080f53.com/passgen/" rel="noopener noreferrer">passGen v3.4</a> is available🎉 For details on what\'s changed, see the <a href="https://github.com/josh-wong/passGen/releases/tag/v3.4.0" target="_blank" rel="noopener noreferrer">release notes</a>.',
+        backgroundColor: '#7c83c2',
+        textColor: '#ffffff',
+        isCloseable: true,
+      },
       docs: {
         sidebar: {
           hideable: true,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -55,7 +55,6 @@ p a {
 /* Announcement Bar */
 div[class^='announcementBar'] {
   font-size: 1.1rem;
-  padding: 20px 0;
 }
 
 /* Home page cards */


### PR DESCRIPTION
## Description

This PR adds an announcement bar to the top of the site about passGen v3.4 release.

## Related issues and/or PRs

- https://github.com/josh-wong/josh-wong.github.io/pull/92

## Changes made

- Added an announcement bar to the Docusaurus configuration file.
- Removed a style that applied padding in the announcement bar in the custom CSS file.

## Checklist

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
