### PR TITLE
Add trigger to run test deployment workflow after PR checklist checker workflow runs

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -9,6 +9,11 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
   workflow_dispatch:
+  # Only trigger, when the build workflow succeeded
+  workflow_run:
+    workflows: ["PR checklist checker"]
+    types:
+      - completed
 
 jobs:
   test-deploy:


### PR DESCRIPTION
## Description

The **Test deployment** workflow that checks if Docusaurus will deploy without errors or not wasn't running because the [recently introduced **PR checklist checker** workflow](https://github.com/josh-wong/josh-wong.github.io/pull/96) is specified to cancel jobs in progress.

Canceling jobs in progress makes it so that the PR checklist checker doesn't run each time an item is checked off. However, that configuration also canceled the **Test deployment** workflow.

## Related issues and/or PRs

- https://github.com/josh-wong/josh-wong.github.io/pull/96

## Changes made

- Added a configuration in `test-deploy.yml` that specifies the job to run after the PR checklist checker workflow finishes running.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
