### PR TITLE
Add feature to run recently queued PR checklist-checking workflow only

### DIFF
--- a/.github/workflows/check-checklist.yml
+++ b/.github/workflows/check-checklist.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: checklist-check-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -9,11 +9,6 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc.
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
   workflow_dispatch:
-  # Only trigger when the build workflow succeeded.
-  workflow_run:
-    workflows: ["PR checklist checker"]
-    types:
-      - completed
 
 jobs:
   test-deploy:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -6,10 +6,10 @@ on:
       - main
     paths:
       - '!.github/**'
-    # Review gh actions docs if you want to further define triggers, paths, etc
+    # Review gh actions docs if you want to further define triggers, paths, etc.
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
   workflow_dispatch:
-  # Only trigger, when the build workflow succeeded
+  # Only trigger when the build workflow succeeded.
   workflow_run:
     workflows: ["PR checklist checker"]
     types:


### PR DESCRIPTION
## Description

This PR improves the workflow for checking the PR checklist.

A previous PR (https://github.com/josh-wong/josh-wong.github.io/pull/101) implemented a fix solution in the `test-deploy.yml` workflow. However, if additional workflows are introduced in this repository, the previous fix introduced in that PR must be implemented in those workflows, which isn't ideal.

## Related issues and/or PRs

- https://github.com/josh-wong/josh-wong.github.io/pull/101

## Changes made

- Specified a group for the PR checklist-checking workflow so that the latest workflow in the `checklist-checker` queue will run and the previous ones will be canceled. However, other workflows will continue to run.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
