### PR TITLE
Fix issue where workflows don't appear in PRs

### DIFF
--- a/.github/workflows/check-checklist.yml
+++ b/.github/workflows/check-checklist.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref  }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-checklist.yml
+++ b/.github/workflows/check-checklist.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

This PR attempts to fix an issue where other workflows don't appear in PRs when the workflow for checking the PR checklist runs.

## Related issues and/or PRs

- **Issue**
  - https://github.com/josh-wong/josh-wong.github.io/issues/102

- **Previous PRs**
  - https://github.com/josh-wong/josh-wong.github.io/pull/103
  - https://github.com/josh-wong/josh-wong.github.io/pull/101

## Changes made

- Added `github.ref ` to `concurrency`.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
