### PR TITLE
Add support for 360-degree images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,14 @@
         "@docusaurus/preset-classic": "3.5.2",
         "@docusaurus/theme-mermaid": "3.5.2",
         "@mdx-js/react": "^3.0.0",
+        "@photo-sphere-viewer/core": "^5.10.0",
         "clsx": "^2.0.0",
         "docusaurus-plugin-image-zoom": "^0.1.4",
         "docusaurus-theme-github-codeblock": "^2.0.2",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "three": "^0.168.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.5.2",
@@ -3139,6 +3141,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@photo-sphere-viewer/core": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/core/-/core-5.10.0.tgz",
+      "integrity": "sha512-VRXPTq6bFxkf5YqmijXLTKV+K05ZZHDoccXBsoxWsS9wKA5gCfKLlebRxQBBazmnwr1KmsLbAIsd1ZGbLdhI4g==",
+      "license": "MIT",
+      "dependencies": {
+        "three": "^0.167.0"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/core/node_modules/three": {
+      "version": "0.167.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
+      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw==",
+      "license": "MIT"
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -15932,6 +15949,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
+    "node_modules/three": {
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==",
+      "license": "MIT"
     },
     "node_modules/thunky": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "@docusaurus/preset-classic": "3.5.2",
     "@docusaurus/theme-mermaid": "3.5.2",
     "@mdx-js/react": "^3.0.0",
+    "@photo-sphere-viewer/core": "^5.10.0",
     "clsx": "^2.0.0",
     "docusaurus-plugin-image-zoom": "^0.1.4",
     "docusaurus-theme-github-codeblock": "^2.0.2",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "three": "^0.168.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.5.2",

--- a/src/components/Image360Viewer.js
+++ b/src/components/Image360Viewer.js
@@ -1,0 +1,25 @@
+import React, { useEffect, useRef } from 'react';
+import { Viewer } from '@photo-sphere-viewer/core';
+import '@photo-sphere-viewer/core/index.css'; // Import the CSS
+
+const Image360Viewer = ({ imageUrl }) => {
+  const viewerRef = useRef(null);
+
+  useEffect(() => {
+    const viewer = new Viewer({
+      container: viewerRef.current,
+      panorama: imageUrl,
+      navbar: true,  // Optional: shows the navigation bar
+      defaultLat: 0, // Optional: initial vertical angle
+      defaultLong: 0, // Optional: initial horizontal angle
+    });
+
+    return () => {
+      viewer.destroy();
+    };
+  }, [imageUrl]);
+
+  return <div ref={viewerRef} style={{ height: '500px', width: '100%' }} />;
+};
+
+export default Image360Viewer;


### PR DESCRIPTION
## Description

This PR adds support for 360-degree images.

> [!NOTE]
> 
> To add a 360-degree image, place the image in the `static/img/360/` folder and add the following to the `.mdx` file that you want the image on. Be sure to replace `<FILE_NAME>` with the name of the file.
> 
> ```markdown
> # Heading 1
> 
> import Image360Viewer from '@site/src/components/Image360Viewer';
> 
> ...
> 
> <Image360Viewer imageUrl="/img/360/<FILE_NAME>.jpg" />
>
> ...
> ```

## Related issues and/or PRs

N/A

## Changes made

- Added `@photo-sphere-viewer/core` and its dependency `three` to `package.json`.
- Created `Image360Viewer.js`, which handles the rendering of the 360-degree images in Docusaurus by using the dependencies. 

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
