### PR TITLE
Fix error in repository name

### DIFF
--- a/.github/workflows/auto-create-pr-cd-component.yml
+++ b/.github/workflows/auto-create-pr-cd-component.yml
@@ -1,10 +1,10 @@
-# This workflow auto-creates PRs for docs that have been updated in my "cd-component" repository.
-name: ✨ Auto-create PR - cd-component docs
+# This workflow auto-creates PRs for docs that have been updated in my "cd-collection" repository.
+name: ✨ Auto-create PR - cd-collection docs
 
 on:
   push:
     branches:
-      - cd-component/**
+      - cd-collection/**
       
 jobs:
   create-pull-request:
@@ -16,13 +16,13 @@ jobs:
           script: |
             const { repo, owner } = context.repo;
             const result = await github.rest.pulls.create({
-              title: 'AUTO: Docs sync - `cd-component`',
+              title: 'AUTO: Docs sync - `cd-collection`',
               owner,
               repo,
               head: '${{ github.ref_name }}',
               base: 'main',
               body: [
-                'This is an automated pull request (PR) to sync changes to docs in the [josh-wong/cd-component](https://github.com/josh-wong/cd-component) repo to this repo.',
+                'This is an automated pull request (PR) to sync changes to docs in the [josh-wong/cd-collection](https://github.com/josh-wong/cd-collection) repo to this repo.',
                 '',
                 'Before merging this PR, confirm the following:',
                 '',


### PR DESCRIPTION
## Description

This PR fixes an error in the workflow for auto-creating a PR from the `cd-collection/update-docs` branch when the `cd-collection` repository is updated.

## Related issues and/or PRs

- Workflow originally added in #122.

## Changes made

- Changed `cd-component` to `cd-collection`.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
