### PR TITLE
Add `cd-collection` to Projects dropdown menu in navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -218,6 +218,11 @@ const config = {
               },
               {
                 type: 'doc',
+                label: 'CD collection💿',
+                docId: 'cd-collection/index',
+              },
+              {
+                type: 'doc',
                 label: 'Microsoft Zune device and software setup🎵',
                 docId: 'zune-software-setup/index',
               },


### PR DESCRIPTION
## Description

This PR adds a link to my CD collection doc in the dropdown menu in the navbar. That doc originates from the [cd-collection](https://github.com/josh-wong/cd-collection) repository.

> [!NOTE]
>
> I'll consider creating separate pages by alphanumeric character at a later time.

## Related issues and/or PRs

- https://github.com/josh-wong/josh-wong.github.io/pull/124

## Changes made

- Added `cd-collection` to the dropdown menu in the navbar.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
