### PR TITLE
Revise `music-collection` labels in sidebar nav

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -70,14 +70,14 @@ const sidebars = {
       ],
     },
   ],
-  cdCollection: [
+  musicCollection: [
     {
       type: 'doc',
-      label: 'CD collection',
+      label: 'Music collection',
       id: 'music-collection/index',
     },
     {
-      'A-Z by artist': [
+      'A-Z (by artist)': [
         'music-collection/a',
         'music-collection/b',
         'music-collection/c',
@@ -105,7 +105,7 @@ const sidebars = {
         'music-collection/y',
         'music-collection/z',
       ],
-      '0-9 by artist': [
+      '0-9 (by artist)': [
         'music-collection/0',
         'music-collection/1',
         'music-collection/2',


### PR DESCRIPTION
## Description

This PR slightly revises the `music-collection` labels in the sidebar navigation.

## Related issues and/or PRs

N/A

## Changes made

- Changed "CD collection" to "music collection."
- Put "by artist" in parentheses.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
