### PR TITLE
Fix transparent notification dropdown menu on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -156,7 +156,7 @@ html[data-theme="dark"] .badge {
   background-image: url("/img/rss-mark.svg");
   background-size: contain;
   content: "";
-  position: relative;
+  position: inherit;
   width: 24px;
   height: 24px;
 }
@@ -238,9 +238,10 @@ html[data-theme="dark"] g[class^='label'] text {
   background-color: white;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 4px;
+  left: 12px;
   position: absolute;
   top: 38px;
-  width: 300px;
+  width: 293px;
   z-index: 1000;
 }
 
@@ -274,9 +275,10 @@ html[data-theme="dark"] .notification-dropdown {
   border-bottom: 1px solid invert(90%);
   border-radius: 4px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.9);
+  left: 12px;
   position: absolute;
   top: 38px;
-  width: 300px;
+  width: 293px;
   z-index: 1000;
 }
 
@@ -292,7 +294,7 @@ html[data-theme="dark"] .notification-dropdown {
 @media (max-width: 997px) {
   .navbar-sidebar .notification-wrapper {
     display: flex; /* Make it visible only in the sidebar on mobile */
-    position: sticky;
+    position: relative;
   }
 
   .notification-count {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -229,7 +229,7 @@ html[data-theme="dark"] g[class^='label'] text {
   height: 20px;
   justify-content: center;
   position: absolute;
-  right: -5px;
+  right: -2px;
   top: 2px;
   width: 20px;
 }
@@ -307,7 +307,7 @@ html[data-theme="dark"] .notification-dropdown {
     height: 20px;
     justify-content: center;
     position: relative;
-    right: 0px;
+    right: 2px;
     top: 2px;
     width: 20px;
   }


### PR DESCRIPTION
## Description

This PR fixes an issue where the notification dropdown menu (introduced in #121) is transparent when expanded on mobile devices.

## Related issues and/or PRs

- #121

## Changes made

- Changed the `position` style for `.notification-dropdown` to make the dropdown menu cover the icons behind the dropdown menu on mobile.
- Changed the `width` style for `.navbar-sidebar .notification-wrapper` to make the notification dropdown menu stay within the expanded menu on mobile.
- Changed the `position` style for `.header-rss-link::before` to make the RSS icon match the same behavior of the other icons in the navbar on mobile.
- Reduced the distance between the notification bell icon and the notification count.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
