### PR TITLE
Add Microsoft Clarity code to all pages

### DIFF
--- a/src/theme/DocsRoot/index.tsx
+++ b/src/theme/DocsRoot/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames, HtmlClassNameProvider} from '@docusaurus/theme-common';
+import renderRoutes from '@docusaurus/renderRoutes';
+import Layout from '@theme/Layout';
+import Clarity from '@microsoft/clarity';
+
+import type {Props} from '@theme/DocVersionRoot';
+
+const projectId = "p9179dcazx"
+
+Clarity.init(projectId);
+
+export default function DocsRoot(props: Props): JSX.Element {
+  return (
+    <HtmlClassNameProvider className={clsx(ThemeClassNames.wrapper.docsPages)}>
+      <Layout>{renderRoutes(props.route.routes!)}</Layout>
+    </HtmlClassNameProvider>
+  );
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// Default implementation, that you can customize
+export default function Root({children}) {
+  return <>{children}</>;
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,4 +1,8 @@
 import React from 'react';
+import Clarity from '@microsoft/clarity';
+
+const projectId = "p9179dcazx"
+Clarity.init(projectId);
 
 // Default implementation, that you can customize
 export default function Root({children}) {


### PR DESCRIPTION
## Description

This PR adds Microsoft Clarity code to all pages on the docs site.

## Related issues and/or PRs

- This should have bee included in https://github.com/josh-wong/josh-wong.github.io/pull/151.

## Changes made

Added 
<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
