### PR TITLE
Add cookie consent banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "docusaurus-theme-github-codeblock": "^2.0.2",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
+        "react-cookie-consent": "9.0.0",
         "react-dom": "^18.0.0",
         "three": "^0.168.0"
       },
@@ -9469,6 +9470,12 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14006,6 +14013,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-cookie-consent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-9.0.0.tgz",
+      "integrity": "sha512-Blyj+m+Zz7SFHYqT18p16EANgnSg2sIyU6Yp3vk83AnOnSW7qnehPkUe4+8+qxztJrNmCH5GP+VHsWzAKVOoZA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-cookie": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docusaurus-theme-github-codeblock": "^2.0.2",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
+    "react-cookie-consent": "9.0.0",
     "react-dom": "^18.0.0",
     "three": "^0.168.0"
   },

--- a/src/pages/cookies/index.mdx
+++ b/src/pages/cookies/index.mdx
@@ -1,0 +1,28 @@
+# Cookie policy
+
+This website, 080f53.com, uses cookies to improve your experience, enhance the functionality of my website, and personalize content. Cookies are small text files stored on your device by my website.
+
+I use Microsoft Clarity and Google Tag Manager cookies for the following purposes:
+
+- **Necessary cookies:** These cookies are essential for you to navigate my website and access its basic features.
+- **Performance cookies:** These cookies help me understand how visitors interact with my content, which improves my ability to create relevant and engaging blog posts, projects, and updates.
+- **Functionality cookies:** These cookies enable features like commenting, social sharing, and form submissions on my website.
+
+## Consent
+
+By visiting or using this website, you consent to the use of cookies by me.
+
+If you do not consent to my use of cookies, please [contact me](about.mdx#contact) to disable them.
+
+Cookies typically stay active for a limited time, usually until you close your browser or delete the cookie. However, some cookies may remain active for longer periods, such as:
+
+- **Session cookies:** These are deleted when you close your browser.
+- **Persistent cookies:** These remain active for a set period of time (usually up to 1 year).
+
+## Changes to cookie policy
+
+I reserve the right to update this cookie policy at any time. Changes will be effective immediately upon posting.
+
+## Contact me
+
+If you have any questions about my cookie policy or consent, please [contact me](about.mdx#contact).

--- a/src/pages/cookies/index.mdx
+++ b/src/pages/cookies/index.mdx
@@ -1,0 +1,28 @@
+# Cookie policy
+
+This website, 080f53.com, uses cookies to improve your experience, enhance the functionality of my website, and personalize content. Cookies are small text files stored on your device by my website.
+
+I use Microsoft Clarity and Google Tag Manager cookies for the following purposes:
+
+- **Necessary cookies:** These cookies are essential for you to navigate my website and access its basic features.
+- **Performance cookies:** These cookies help me understand how visitors interact with my content, which improves my ability to create relevant and engaging blog posts, projects, and updates.
+- **Functionality cookies:** These cookies enable features like commenting, social sharing, and form submissions on my website.
+
+## Consent
+
+By visiting or using this website, you consent to the use of cookies by me.
+
+If you do not consent to my use of cookies, please [contact me](/about#contact) to disable them.
+
+Cookies typically stay active for a limited time, usually until you close your browser or delete the cookie. However, some cookies may remain active for longer periods, such as:
+
+- **Session cookies:** These are deleted when you close your browser.
+- **Persistent cookies:** These remain active for a set period of time (usually up to 1 year).
+
+## Changes to cookie policy
+
+I reserve the right to update this cookie policy at any time. Changes will be effective immediately upon posting.
+
+## Contact me
+
+If you have any questions about my cookie policy or consent, please [contact me](/about#contact).

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -5,21 +5,38 @@ import CookieConsent, { Cookies, getCookieConsentValue } from "react-cookie-cons
 const projectId = "p9179dcazx"
 Clarity.init(projectId);
 
-window.addEventListener("CookieConsent", () => window.clarity('consent'));
+// window.addEventListener("CookieConsent", () => window.clarity('consent'));
 
 export default function Root({children}) {
-  return <>
-    {children}
-    <div>
-      <CookieConsent
-        location="bottom"
-        buttonText="I understand"
-        style={{ backgroundColor: "#080f53", padding: "20px" }}
-        buttonStyle={{ backgroundColor: "#fff", color: "#000", fontWeight: "500", fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'" }}
-        expires={150}
-      >
-        This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the cookie policy and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.{" "}
-      </CookieConsent>
-    </div>
-  </>;
+  const handleConsentAccept = () => {
+    // Set the clarity consent and trigger the consent event
+    Clarity.consent(true);
+    console.log("Clarity consent granted.");
+  };
+
+  return (
+    <>
+      {children}
+      <div>
+        <CookieConsent
+          location="bottom"
+          buttonText="I understand"
+          style={{
+            backgroundColor:"#080f53",
+            padding: "20px"
+          }}
+          buttonStyle={{
+            backgroundColor: "#fff",
+            color: "#000",
+            fontWeight: "500",
+            fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"
+          }}
+          expires={150}
+          onAccept={handleConsentAccept}
+        >
+          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the cookie policy and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.{" "}
+        </CookieConsent>
+      </div>
+    </>
+  );
 }

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -49,7 +49,7 @@ export default function Root({ children }) {
           expires={150}
           onAccept={handleConsentAccept}
         >
-          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the cookie policy and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.
+          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the <a href="/cookies">cookie policy</a> and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.
         </CookieConsent>
       </div>
     </>

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -8,18 +8,35 @@ Clarity.init(projectId);
 window.addEventListener("CookieConsent", () => window.clarity('consent'));
 
 export default function Root({children}) {
-  return <>
-    {children}
-    <div>
-      <CookieConsent
-        location="bottom"
-        buttonText="I understand"
-        style={{ backgroundColor: "#080f53", padding: "20px" }}
-        buttonStyle={{ backgroundColor: "#fff", color: "#000", fontWeight: "500", fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'" }}
-        expires={150}
-      >
-        This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the cookie policy and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.{" "}
-      </CookieConsent>
-    </div>
-  </>;
+  const handleConsentAccept = () => {
+    // Set the clarity consent and trigger the consent event
+    Clarity.consent(true);
+    console.log("Clarity consent granted.");
+  };
+
+  return (
+    <>
+      {children}
+      <div>
+        <CookieConsent
+          location="bottom"
+          buttonText="I understand"
+          style={{
+            backgroundColor:"#080f53",
+            padding: "20px"
+          }}
+          buttonStyle={{
+            backgroundColor: "#fff",
+            color: "#000",
+            fontWeight: "500",
+            fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"
+          }}
+          expires={150}
+          onAccept={handleConsentAccept}
+        >
+          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the cookie policy and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.{" "}
+        </CookieConsent>
+      </div>
+    </>
+  );
 }

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,10 +1,25 @@
 import React from 'react';
 import Clarity from '@microsoft/clarity';
+import CookieConsent, { Cookies, getCookieConsentValue } from "react-cookie-consent";
 
 const projectId = "p9179dcazx"
 Clarity.init(projectId);
 
-// Default implementation, that you can customize
+window.addEventListener("CookieConsent", () => window.clarity('consent'));
+
 export default function Root({children}) {
-  return <>{children}</>;
+  return <>
+    {children}
+    <div>
+      <CookieConsent
+        location="bottom"
+        buttonText="I understand"
+        style={{ backgroundColor: "#080f53", padding: "20px" }}
+        buttonStyle={{ backgroundColor: "#fff", color: "#000", fontWeight: "500", fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'" }}
+        expires={150}
+      >
+        This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the cookie policy and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.{" "}
+      </CookieConsent>
+    </div>
+  </>;
 }


### PR DESCRIPTION
## Description

This PR adds a cookie consent banner to use in conjunction with Microsoft Clarity.

## Related issues and/or PRs

- #153 
- #151 

## Changes made

- Added the [**react-cookie-consent**](https://www.npmjs.com/package/react-cookie-consent) plugin.
- Added a cookie consent banner.
- Added a cookie policy page.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
