### PR TITLE
Revise text and fix link color in cookie consent banner

### DIFF
--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -36,7 +36,6 @@ export default function Root({ children }) {
           location="bottom"
           buttonText="I understand"
           style={{
-            backgroundColor: "#080f53",
             padding: "20px",
           }}
           buttonStyle={{
@@ -49,7 +48,7 @@ export default function Root({ children }) {
           expires={150}
           onAccept={handleConsentAccept}
         >
-          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the <a href="/cookies">cookie policy</a> and consent to the use of cookies so that I can make data-driven decisions to help improve your browsing experience and provide you with personalized content.
+          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the <a href="/cookies" style={{color: "white", textDecorationLine: "underline"}}>cookie policy</a> and consent to the use of cookies so that I can make data-driven decisions to help improve your browsing experience and provide you with personalized content.
         </CookieConsent>
       </div>
     </>

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -49,7 +49,7 @@ export default function Root({ children }) {
           expires={150}
           onAccept={handleConsentAccept}
         >
-          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the <a href="/cookies">cookie policy</a> and consent to the use of cookies to improve your browsing experience, personalize content, and analyze website traffic.
+          This website uses cookies to enhance the user experience. By continuing to use this website, you acknowledge that you have read and understood the <a href="/cookies">cookie policy</a> and consent to the use of cookies so that I can make data-driven decisions to help improve your browsing experience and provide you with personalized content.
         </CookieConsent>
       </div>
     </>


### PR DESCRIPTION
## Description

This PR:

- Clarifies the wording in the cookie consent banner.
- Fixes an issue where the hyperlinked text to the cookie policy in the cookie consent banner is impossible to see when the site is using the light theme.

## Related issues and/or PRs

- #155 

## Changes made

- Revised the text in the cookie consent banner for clarity.
- Hard-coded a style for the cookie consent banner to make the hyperlinked text appear when the site is using the light theme.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
