### PR TITLE
Add missing link to music collection to Projects page; fix navigation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -237,13 +237,13 @@ const config = {
               },
               {
                 type: 'doc',
-                label: 'Music collection💿',
-                docId: 'music-collection/index',
+                label: 'Microsoft Zune device and software setup🎵',
+                docId: 'zune-software-setup/index',
               },
               {
                 type: 'doc',
-                label: 'Microsoft Zune device and software setup🎵',
-                docId: 'zune-software-setup/index',
+                label: 'Music collection💿',
+                docId: 'music-collection/index',
               },
               {
                 type: 'doc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -42,13 +42,13 @@ const sidebars = {
     },
     {
       type: 'doc',
-      label: 'Music collection',
-      id: 'music-collection/index',
+      label: 'Microsoft Zune device and Zune software setup guide',
+      id: 'zune-software-setup/index',
     },
     {
       type: 'doc',
-      label: 'Microsoft Zune device and Zune software setup guide',
-      id: 'zune-software-setup/index',
+      label: 'Music collection',
+      id: 'music-collection/index',
     },
     {
       type: 'doc',
@@ -103,6 +103,19 @@ const sidebars = {
       ],
     },
   ],
+  zuneSoftwareSetup: [
+    {
+      type: 'doc',
+      label: 'About the Microsoft Zune device and Zune software setup guide',
+      id: 'zune-software-setup/index',
+    },
+    'zune-software-setup/getting-started',
+    'zune-software-setup/installing-the-zune-software',
+    'zune-software-setup/connecting-with-the-zune-software',
+    'zune-software-setup/adding-apps-and-games',
+    'zune-software-setup/conclusion',
+    'zune-software-setup/references',
+  ],
   musicCollection: [
     {
       type: 'doc',
@@ -151,19 +164,6 @@ const sidebars = {
         'music-collection/9',
       ],
     },
-  ],
-  zuneSoftwareSetup: [
-    {
-      type: 'doc',
-      label: 'About the Microsoft Zune device and Zune software setup guide',
-      id: 'zune-software-setup/index',
-    },
-    'zune-software-setup/getting-started',
-    'zune-software-setup/installing-the-zune-software',
-    'zune-software-setup/connecting-with-the-zune-software',
-    'zune-software-setup/adding-apps-and-games',
-    'zune-software-setup/conclusion',
-    'zune-software-setup/references',
   ],
   passgen: [
     {

--- a/src/components/Cards/projects.tsx
+++ b/src/components/Cards/projects.tsx
@@ -101,6 +101,18 @@ const CardsPersonalProjects = [
     ),
   },
   {
+    name: 'Music collection💿',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: '/projects/music-collection',
+    },
+    description: (
+      <Translate id="personal.musicCollection.description">
+        List of CDs and vinyl records that I currently have in my collection
+      </Translate>
+    ),
+  },
+  {
     name: 'passGen🔐',
     // image: '<LINK_TO>.png',
     url: {


### PR DESCRIPTION
## Description

This PR adds a missing link to the music collection home page to the Projects page and fixes the navigation.

## Related issues and/or PRs

N/A

## Changes made

- Added a link to the music collection home page to the Projects page.
- Fixed the placement of links to the music collection home page and the Zune setup home page since they weren't in alphabetical order.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
