### PR TITLE
Add dedicated Signal sticker page; update header, footer, and sidebar navigation

### DIFF
--- a/docs/signal-stickers/index.mdx
+++ b/docs/signal-stickers/index.mdx
@@ -1,0 +1,11 @@
+---
+displayed_sidebar: projects
+---
+
+# Signal sticker packs
+
+import { CardRowSignalStickers } from '/src/components/Cards/signalStickers';
+
+The following are some Signal stickers that I've created.
+
+<CardRowSignalStickers />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -312,17 +312,16 @@ const config = {
             title: '080F53',
             items: [
               {
+                label: 'Blog',
+                to: '/blog',
+              },
+              {
+                label: 'Projects',
+                to: '/projects',
+              },
+              {
                 label: 'About',
                 to: '/about',
-              },
-            ],
-          },
-          {
-            title: 'Projects',
-            items: [
-              {
-                label: 'Documentation',
-                to: '/projects',
               },
             ],
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -223,6 +223,7 @@ const config = {
           {
             type: 'dropdown',
             label: 'Projects',
+            to: 'projects',
             position: 'left',
             items: [
               {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -263,6 +263,11 @@ const config = {
             position: 'right',
             notifications: [ // Instead of deleting notifications, just comment them out so that it's easier to see the history of notifications.
               {
+                id: 4,
+                message: 'New Signal sticker pack!: 1950s-60s Blue Note jazz musicians🎷',
+                url: 'https://signal.art/addstickers/#pack_id=b406d0f0636508c14222022baa9af677&pack_key=e0641dcf015b9bc27ebbbf6795fc90076e697702221f68e8c74afc0e86332539'
+              },
+              {
                 id: 3,
                 message: 'New feature!: Site notifications🚨',
                 url: '/blog/2024/11/20/site-notification-feature'
@@ -272,11 +277,11 @@ const config = {
                 message: 'Check out the unofficial Baird beer flavor quadrants🍺',
                 url: '/projects/baird-beer-quadrants'
               },
-              {
-                id: 1,
-                message: 'Enjoy Baird beer? Ask the unofficial AI chatbot for recommendations🤖',
-                url: 'https://typebot.co/baird-beer-recommendations-experimental-080f53'
-              },
+              // {
+              //   id: 1,
+              //   message: 'Enjoy Baird beer? Ask the unofficial AI chatbot for recommendations🤖',
+              //   url: 'https://typebot.co/baird-beer-recommendations-experimental-080f53'
+              // },
             ],
           },
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -251,8 +251,9 @@ const config = {
                 docId: 'passgen/index',
               },
               {
-                label: 'Signal sticker pack - "Why Bitcoin Cash?"🎁',
-                href: 'https://signal.art/addstickers/#pack_id=183a3ca8d7ccdcdb8fa7728b17453fbc&pack_key=e9ac42b0e7276edd92d293321d2e51cca64e5744bad567fd9579b51abb78773d',
+                type: 'doc',
+                label: 'Signal sticker packs🎁',
+                docId: 'signal-stickers/index',
               },
             ],
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -261,7 +261,7 @@ const config = {
           {
             type: 'custom-NotificationBell',
             position: 'right',
-            notifications: [
+            notifications: [ // Instead of deleting notifications, just comment them out so that it's easier to see the history of notifications.
               {
                 id: 3,
                 message: 'New feature!: Site notifications🚨',

--- a/sidebars.js
+++ b/sidebars.js
@@ -56,6 +56,11 @@ const sidebars = {
       id: 'passgen/index',
     },
     {
+      type: 'doc',
+      label: 'Signal sticker packs',
+      id: 'signal-stickers/index',
+    },
+    {
       type: 'link',
       label: 'AI chatbot for beer recommendations (unofficial)',
       href: 'https://signal.art/addstickers/#pack_id=183a3ca8d7ccdcdb8fa7728b17453fbc&pack_key=e9ac42b0e7276edd92d293321d2e51cca64e5744bad567fd9579b51abb78773d',

--- a/src/components/Cards/signalStickers.tsx
+++ b/src/components/Cards/signalStickers.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsSignalStickers = [
+  {
+    name: '1950s-60s Blue Note jazz musicians🎷',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'https://signal.art/addstickers/#pack_id=b406d0f0636508c14222022baa9af677&pack_key=e0641dcf015b9bc27ebbbf6795fc90076e697702221f68e8c74afc0e86332539',
+    },
+    description: (
+      <Translate id="personal.signalStickersBlueNotePrivateSide.description">
+        Stickers based on photos in the article "A Blue Note Founder's View of Jazz Music's Private Side"
+      </Translate>
+    ),
+  },
+  {
+    name: 'Why Bitcoin Cash?🪙',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'https://signal.art/addstickers/#pack_id=183a3ca8d7ccdcdb8fa7728b17453fbc&pack_key=e9ac42b0e7276edd92d293321d2e51cca64e5744bad567fd9579b51abb78773d',
+    },
+    description: (
+      <Translate id="personal.signalStickersBch.description">
+        Stickers based on the "Why Bitcoin Cash" brand assets
+      </Translate>
+    ),
+  },
+  // // Card template
+  // {
+  //   name: 'TITLE', // Change this to the title of the Signal sticker pack.
+  //   // image: '<LINK_TO>.png',
+  //   url: {
+  //     page: 'URL', // Change this to the Signal sticker pack URL.
+  //   },
+  // //   description: (
+  // //     <Translate id="personal.zuneSetup.description">
+  // //       ADD DESCRIPTION ABOUT THE SIGNAL STICKER PACK
+  // //     </Translate>
+  // //   ),
+  // },
+];
+
+interface Props {
+  name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ name, /*image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link>
+          <div className="card__body">
+            <h3>{name}</h3>
+            <p>{description}</p>
+          </div>
+        </Link>
+        <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Install</Translate>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CardRowProfessionalProjects(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsProfessionalProjects.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSignalStickers(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSignalStickers.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

This PR adds a page for listing the Signal sticker packs that I've created. Since I've created more than one sticker pack, a page to provide links to those sticker packs is needed.

In addition, this PR updates some navigation in the header, footer, and sidebar.

## Related issues and/or PRs

N/A

## Changes made

- Created a page for listing links to the Signal sticker packs that I've created.
- Created a component for listing the Signal sticker packs.
- Updated links in the **Project** dropdown in the header:
  - Added a link to the **Project** index page.
  - Changed the link to the "Why Bitcoin Cash?" Signal sticker pack to the dedicated Signal sticker pack page.
- Updated the footer for consistency with the header.
- Changed the link to the "Why Bitcoin Cash?" Signal sticker pack to the dedicated Signal sticker pack page in the sidebar navigation.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
