### PR TITLE
Fix broken RSS link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -288,7 +288,7 @@ const config = {
           },
           {
             className: 'header-rss-link',
-            href: 'https://www.080f53.com/rss.xml',
+            href: 'https://www.080f53.com/blog/rss.xml',
             position: 'right',
             'aria-label': 'RSS',
           },


### PR DESCRIPTION
## Description

This PR fixes the broken RSS link in the header. This link became broken in #162 after I made some structural changes in the Docusaurus configuration file.

## Related issues and/or PRs

- Broken link introduced in #162

## Changes made

- Changed the link to the RSS feed in the header from `https://www.080f53.com/rss.xml,` to `https://www.080f53.com/blog/rss.xml`.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
