### PR TITLE
Fix broken links to Baird beer pages

### DIFF
--- a/docs/baird-beer-quadrants/beers-four-seasons-series.mdx
+++ b/docs/baird-beer-quadrants/beers-four-seasons-series.mdx
@@ -54,7 +54,7 @@ The following are descriptions for each of the beers in the quadrant.
         Saison Sayuri: [0.45, 0.65]
     ```
 
-    Read more about [Saison Sayuri](https://bairdbeer.com/beer/saison-sayuri) on the Baird Brewing website.
+    Read more about [Saison Sayuri](https://bairdbeer.com/products/saison-sayuri) on the Baird Brewing website.
   </TabItem>
   <TabItem value="2" label="2">
     <h3>Cool Breeze Pils</h3>
@@ -75,7 +75,7 @@ The following are descriptions for each of the beers in the quadrant.
         Cool Breeze Pils: [0.40, 0.30]
     ```
 
-    Read more about [Cool Breeze Pils](https://bairdbeer.com/beer/cool-breeze-pils) on the Baird Brewing website.
+    Read more about [Cool Breeze Pils](https://bairdbeer.com/products/cool-breeze-pils) on the Baird Brewing website.
   </TabItem>
   <TabItem value="3" label="3">
     <h3>Yabai-Yabai Strong Scotch Ale</h3>
@@ -96,7 +96,7 @@ The following are descriptions for each of the beers in the quadrant.
         Yabai-Yabai Strong Scotch Ale: [0.60, 0.80]
     ```
 
-    Read more about [Yabai-Yabai Strong Scotch Ale](https://bairdbeer.com/beer/yabai-yabai-strong-scotch-ale) on the Baird Brewing website.
+    Read more about [Yabai-Yabai Strong Scotch Ale](https://bairdbeer.com/products/yabai-yabai-strong-scotch-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="4" label="4">
     <h3>Dark Sky Imperial Stout</h3>
@@ -117,6 +117,6 @@ The following are descriptions for each of the beers in the quadrant.
         Dark Sky Imperial Stout: [0.50, 0.75]
     ```
 
-    Read more about [Dark Sky Imperial Stout](https://bairdbeer.com/beer/dark-sky-imperial-stout) on the Baird Brewing website.
+    Read more about [Dark Sky Imperial Stout](https://bairdbeer.com/products/dark-sky-imperial-stout) on the Baird Brewing website.
   </TabItem>
 </Tabs>

--- a/docs/baird-beer-quadrants/beers-fruitful-life-series.mdx
+++ b/docs/baird-beer-quadrants/beers-fruitful-life-series.mdx
@@ -60,7 +60,7 @@ The following are descriptions for each of the beers in the quadrant.
         The Carpenter's Mikan Ale: [0.30, 0.85]
     ```
 
-    Read more about [The Carpenter's Mikan Ale](https://bairdbeer.com/beer/the-carpenters-mikan-ale) on the Baird Brewing website.
+    Read more about [The Carpenter's Mikan Ale](https://bairdbeer.com/products/the-carpenters-mikan-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="2" label="2">
     <h3>Temple Garden Yuzu Ale</h3>
@@ -81,7 +81,7 @@ The following are descriptions for each of the beers in the quadrant.
         Temple Garden Yuzu Ale: [0.40, 0.80]
     ```
 
-    Read more about [Temple Garden Yuzu Ale](https://bairdbeer.com/beer/temple-garden-yuzu-ale) on the Baird Brewing website.
+    Read more about [Temple Garden Yuzu Ale](https://bairdbeer.com/products/temple-garden-yuzu-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="3" label="3">
     <h3>Second Strike Apple Ale</h3>
@@ -102,7 +102,7 @@ The following are descriptions for each of the beers in the quadrant.
         Second Strike Apple Ale: [0.30, 0.70]
     ```
 
-    Read more about [Second Strike Apple Ale](https://bairdbeer.com/beer/second-strike-apple-ale) on the Baird Brewing website.
+    Read more about [Second Strike Apple Ale](https://bairdbeer.com/products/second-strike-apple-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="4" label="4">
     <h3>Fruitful Life Citrus IPA</h3>
@@ -123,7 +123,7 @@ The following are descriptions for each of the beers in the quadrant.
         Fruitful Life Citrus IPA: [0.60, 0.75]
     ```
 
-    Read more about [Fruitful Life Citrus IPA](https://bairdbeer.com/beer/fruitful-life-citrus-ipa) on the Baird Brewing website.
+    Read more about [Fruitful Life Citrus IPA](https://bairdbeer.com/products/fruitful-life-citrus-ipa) on the Baird Brewing website.
   </TabItem>
   <TabItem value="5" label="5">
     <h3>Shizuoka Summer Mikan Ale</h3>
@@ -144,7 +144,7 @@ The following are descriptions for each of the beers in the quadrant.
         Shizuoka Summer Mikan Ale: [0.35, 0.85]
     ```
 
-    Read more about [Shizuoka Summer Mikan Ale](https://bairdbeer.com/beer/shizuoka-summer-mikan-ale) on the Baird Brewing website.
+    Read more about [Shizuoka Summer Mikan Ale](https://bairdbeer.com/products/shizuoka-summer-mikan-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="6" label="6">
     <h3>Japan Tale Ale</h3>
@@ -165,7 +165,7 @@ The following are descriptions for each of the beers in the quadrant.
         Japan Tale Ale: [0.40, 0.65]
     ```
 
-    Read more about [Japan Tale Ale](https://bairdbeer.com/beer/japan-tale-ale) on the Baird Brewing website.
+    Read more about [Japan Tale Ale](https://bairdbeer.com/products/japan-tale-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="7" label="7">
     <h3>Asian Beauty Biwa Ale</h3>
@@ -186,7 +186,7 @@ The following are descriptions for each of the beers in the quadrant.
         Asian Beauty Biwa Ale: [0.35, 0.70]
     ```
 
-    Read more about [Asian Beauty Biwa Ale](https://bairdbeer.com/beer/asian-beauty-biwa-lager) on the Baird Brewing website.
+    Read more about [Asian Beauty Biwa Ale](https://bairdbeer.com/products/asian-beauty-biwa-lager) on the Baird Brewing website.
   </TabItem>
   <TabItem value="8" label="8">
     <h3>Country Girl Kabocha Ale</h3>
@@ -207,7 +207,7 @@ The following are descriptions for each of the beers in the quadrant.
         Country Girl Kabocha Ale: [0.40, 0.55]
     ```
 
-    Read more about [Country Girl Kabocha Ale](https://bairdbeer.com/beer/country-girl-kabocha-ale) on the Baird Brewing website.
+    Read more about [Country Girl Kabocha Ale](https://bairdbeer.com/products/country-girl-kabocha-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="9" label="9">
     <h3>Smoke & Fire Habanero Stout</h3>
@@ -228,7 +228,7 @@ The following are descriptions for each of the beers in the quadrant.
         Smoke & Fire Habanero Stout: [0.50, 0.40]
     ```
 
-    Read more about [Smoke & Fire Habanero Stout](https://bairdbeer.com/beer/smoke-fire-habanero-stout) on the Baird Brewing website.
+    Read more about [Smoke & Fire Habanero Stout](https://bairdbeer.com/products/smoke-fire-habanero-stout) on the Baird Brewing website.
   </TabItem>
   <TabItem value="10" label="10">
     <h3>Jubilation Ale</h3>
@@ -249,6 +249,6 @@ The following are descriptions for each of the beers in the quadrant.
         Jubilation Ale: [0.45, 0.60]
     ```
 
-    Read more about [Jubilation Ale](https://bairdbeer.com/beer/jubilation-ale) on the Baird Brewing website.
+    Read more about [Jubilation Ale](https://bairdbeer.com/products/jubilation-ale) on the Baird Brewing website.
   </TabItem>
 </Tabs>

--- a/docs/baird-beer-quadrants/beers-monthly-style-series.mdx
+++ b/docs/baird-beer-quadrants/beers-monthly-style-series.mdx
@@ -62,7 +62,7 @@ The following are descriptions for each of the beers in the quadrant.
         Hatsujozo India Pale Lager: [0.65, 0.60]
     ```
 
-    Read more about [Hatsujozo India Pale Lager](https://bairdbeer.com/beer/hatsujozo-india-pale-lager) on the Baird Brewing website.
+    Read more about [Hatsujozo India Pale Lager](https://bairdbeer.com/products/hatsujozo-india-pale-lager) on the Baird Brewing website.
   </TabItem>
   <TabItem value="2" label="2">
     <h3>Ganko Oyaji Barley Wine</h3>
@@ -83,7 +83,7 @@ The following are descriptions for each of the beers in the quadrant.
         Ganko Oyaji Barley Wine: [0.50, 0.35]
     ```
 
-    Read more about [Ganko Oyaji Barley Wine](https://bairdbeer.com/beer/ganko-oyaji-barley-wine) on the Baird Brewing website.
+    Read more about [Ganko Oyaji Barley Wine](https://bairdbeer.com/products/ganko-oyaji-barley-wine) on the Baird Brewing website.
   </TabItem>
   <TabItem value="3" label="3">
     <h3>Morning Coffee Stout</h3>
@@ -104,7 +104,7 @@ The following are descriptions for each of the beers in the quadrant.
         Morning Coffee Stout: [0.40, 0.25]
     ```
 
-    Read more about [Morning Coffee Stout](https://bairdbeer.com/beer/morning-coffee-stout) on the Baird Brewing website.
+    Read more about [Morning Coffee Stout](https://bairdbeer.com/products/morning-coffee-stout) on the Baird Brewing website.
   </TabItem>
   <TabItem value="4" label="4">
     <h3>Bureiko Jikan Strong Golden Ale</h3>
@@ -125,7 +125,7 @@ The following are descriptions for each of the beers in the quadrant.
         Bureiko Jikan Strong Golden Ale: [0.45, 0.55]
     ```
 
-    Read more about [Bureiko Jikan Strong Golden Ale](https://bairdbeer.com/beer/bureiko-jikan-strong-golden-ale) on the Baird Brewing website.
+    Read more about [Bureiko Jikan Strong Golden Ale](https://bairdbeer.com/products/bureiko-jikan-strong-golden-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="5" label="5">
     <h3>Four Sisters Spring Bock</h3>
@@ -146,7 +146,7 @@ The following are descriptions for each of the beers in the quadrant.
         Four Sisters Spring Bock: [0.40, 0.45]
     ```
 
-    Read more about [Four Sisters Spring Bock](https://bairdbeer.com/beer/four-sisters-spring-bock) on the Baird Brewing website.
+    Read more about [Four Sisters Spring Bock](https://bairdbeer.com/products/four-sisters-spring-bock) on the Baird Brewing website.
   </TabItem>
   <TabItem value="6" label="6">
     <h3>Hop Havoc Imperial Pale Ale</h3>
@@ -167,7 +167,7 @@ The following are descriptions for each of the beers in the quadrant.
         Hop Havoc Imperial Pale Ale: [0.75, 0.70]
     ```
 
-    Read more about [Hop Havoc Imperial Pale Ale](https://bairdbeer.com/beer/hop-havoc-imperial-pale-ale) on the Baird Brewing website.
+    Read more about [Hop Havoc Imperial Pale Ale](https://bairdbeer.com/products/hop-havoc-imperial-pale-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="7" label="7">
     <h3>Joie de Vivre</h3>
@@ -188,7 +188,7 @@ The following are descriptions for each of the beers in the quadrant.
         Joie de Vivre: [0.35, 0.55]
     ```
 
-    Read more about [Joie de Vivre](https://bairdbeer.com/beer/joie-de-vivre) on the Baird Brewing website.
+    Read more about [Joie de Vivre](https://bairdbeer.com/products/joie-de-vivre) on the Baird Brewing website.
   </TabItem>
   <TabItem value="8" label="8">
     <h3>Public House Bitter</h3>
@@ -209,7 +209,7 @@ The following are descriptions for each of the beers in the quadrant.
         Public House Bitter: [0.60, 0.50]
     ```
 
-    Read more about [Public House Bitter](https://bairdbeer.com/beer/public-house-bitter) on the Baird Brewing website.
+    Read more about [Public House Bitter](https://bairdbeer.com/products/public-house-bitter) on the Baird Brewing website.
   </TabItem>
   <TabItem value="9" label="9">
     <h3>Brewer's Nightmare Rye IPA</h3>
@@ -230,7 +230,7 @@ The following are descriptions for each of the beers in the quadrant.
         Brewer's Nightmare Rye IPA: [0.70, 0.65]
     ```
 
-    Read more about [Brewer's Nightmare Rye IPA](https://bairdbeer.com/beer/brewers-nightmare-rye-ipa) on the Baird Brewing website.
+    Read more about [Brewer's Nightmare Rye IPA](https://bairdbeer.com/products/brewers-nightmare-rye-ipa) on the Baird Brewing website.
   </TabItem>
   <TabItem value="10" label="10">
     <h3>Fest Lager</h3>
@@ -251,7 +251,7 @@ The following are descriptions for each of the beers in the quadrant.
         Fest Lager: [0.50, 0.45]
     ```
 
-    Read more about [Fest Lager](https://bairdbeer.com/beer/fest-lager) on the Baird Brewing website.
+    Read more about [Fest Lager](https://bairdbeer.com/products/fest-lager) on the Baird Brewing website.
   </TabItem>
   <TabItem value="11" label="11">
     <h3>West Coast Wheat Wine</h3>
@@ -272,7 +272,7 @@ The following are descriptions for each of the beers in the quadrant.
         West Coast Wheat Wine: [0.55, 0.40]
     ```
 
-    Read more about [West Coast Wheat Wine](https://bairdbeer.com/beer/west-coast-wheat-wine) on the Baird Brewing website.
+    Read more about [West Coast Wheat Wine](https://bairdbeer.com/products/west-coast-wheat-wine) on the Baird Brewing website.
   </TabItem>
   <TabItem value="12" label="12">
     <h3>Bakayaro! Ale</h3>
@@ -293,6 +293,6 @@ The following are descriptions for each of the beers in the quadrant.
         Bakayaro! Ale: [0.85, 0.60]
     ```
 
-    Read more about [Bakayaro! Ale](https://bairdbeer.com/beer/bakayaro-ale) on the Baird Brewing website.
+    Read more about [Bakayaro! Ale](https://bairdbeer.com/products/bakayaro-ale) on the Baird Brewing website.
   </TabItem>
 </Tabs>

--- a/docs/baird-beer-quadrants/beers-year-round.mdx
+++ b/docs/baird-beer-quadrants/beers-year-round.mdx
@@ -60,7 +60,7 @@ The following are descriptions for each of the beers in the quadrant.
         Single Take Session Ale: [0.40, 0.50]
     ```
 
-    Read more about [Single Take Session Ale](https://bairdbeer.com/beer/single-take-session-ale) on the Baird Brewing website.
+    Read more about [Single Take Session Ale](https://bairdbeer.com/products/single-take-session-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="2" label="2">
     <h3>Wheat King Wit</h3>
@@ -79,7 +79,7 @@ The following are descriptions for each of the beers in the quadrant.
         Wheat King Wit: [0.30, 0.70]
     ```
 
-    Read more about [Wheat King Wit](https://bairdbeer.com/beer/wheat-king-wit) on the Baird Brewing website.
+    Read more about [Wheat King Wit](https://bairdbeer.com/products/wheat-king-wit) on the Baird Brewing website.
   </TabItem>
   <TabItem value="3" label="3">
     <h3>Shuzenji Heritage Helles</h3>
@@ -98,7 +98,7 @@ The following are descriptions for each of the beers in the quadrant.
         Shuzenji Heritage Helles: [0.35, 0.40]
     ```
 
-    Read more about [Shuzenji Heritage Helles](https://bairdbeer.com/beer/shuzenji-heritage-helles) on the Baird Brewing website.
+    Read more about [Shuzenji Heritage Helles](https://bairdbeer.com/products/shuzenji-heritage-helles) on the Baird Brewing website.
   </TabItem>
   <TabItem value="4" label="4">
     <h3>Numazu Lager</h3>
@@ -117,7 +117,7 @@ The following are descriptions for each of the beers in the quadrant.
         Numazu Lager: [0.30, 0.45]
     ```
 
-    Read more about [Numazu Lager](https://bairdbeer.com/beer/numazu-lager) on the Baird Brewing website.
+    Read more about [Numazu Lager](https://bairdbeer.com/products/numazu-lager) on the Baird Brewing website.
   </TabItem>
   <TabItem value="5" label="5">
     <h3>Rising Sun Pale Ale</h3>
@@ -136,7 +136,7 @@ The following are descriptions for each of the beers in the quadrant.
         Rising Sun Pale Ale: [0.60, 0.55]
     ```
 
-    Read more about [Rising Sun Pale Ale](https://bairdbeer.com/beer/rising-sun-pale-ale) on the Baird Brewing website.
+    Read more about [Rising Sun Pale Ale](https://bairdbeer.com/products/rising-sun-pale-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="6" label="6">
     <h3>Wabi-Sabi Japan Pale Ale</h3>
@@ -155,7 +155,7 @@ The following are descriptions for each of the beers in the quadrant.
         Wabi-Sabi Japan Pale Ale: [0.55, 0.60]
     ```
 
-    Read more about [Wabi-Sabi Japan Pale Ale](https://bairdbeer.com/beer/wabi-sabi-japan-pale-ale) on the Baird Brewing website.
+    Read more about [Wabi-Sabi Japan Pale Ale](https://bairdbeer.com/products/wabi-sabi-japan-pale-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="7" label="7">
     <h3>Red Rose Amber Ale</h3>
@@ -174,7 +174,7 @@ The following are descriptions for each of the beers in the quadrant.
         Red Rose Amber Ale: [0.45, 0.50]
     ```
 
-    Read more about [Red Rose Amber Ale](https://bairdbeer.com/beer/red-rose-amber-ale) on the Baird Brewing website.
+    Read more about [Red Rose Amber Ale](https://bairdbeer.com/products/red-rose-amber-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="8" label="8">
     <h3>Angry Boy Brown Ale</h3>
@@ -193,7 +193,7 @@ The following are descriptions for each of the beers in the quadrant.
         Angry Boy Brown Ale: [0.50, 0.30]
     ```
 
-    Read more about [Angry Boy Brown Ale](https://bairdbeer.com/beer/angry-boy-brown-ale) on the Baird Brewing website.
+    Read more about [Angry Boy Brown Ale](https://bairdbeer.com/products/angry-boy-brown-ale) on the Baird Brewing website.
   </TabItem>
   <TabItem value="9" label="9">
     <h3>Teikoku IPA</h3>
@@ -212,7 +212,7 @@ The following are descriptions for each of the beers in the quadrant.
         Teikoku IPA: [0.70, 0.60]
     ```
 
-    Read more about [Teikoku IPA](https://bairdbeer.com/beer/teikoku-ipa) on the Baird Brewing website.
+    Read more about [Teikoku IPA](https://bairdbeer.com/products/teikoku-ipa) on the Baird Brewing website.
   </TabItem>
   <TabItem value="10" label="10">
     <h3>Suruga Bay Imperial IPA</h3>
@@ -231,7 +231,7 @@ The following are descriptions for each of the beers in the quadrant.
         Suruga Bay Imperial IPA: [0.80, 0.70]
     ```
 
-    Read more about [Suruga Bay Imperial IPA](https://bairdbeer.com/beer/suruga-bay-imperial-ipa) on the Baird Brewing website.
+    Read more about [Suruga Bay Imperial IPA](https://bairdbeer.com/products/suruga-bay-imperial-ipa) on the Baird Brewing website.
   </TabItem>
   <TabItem value="11" label="11">
     <h3>Shimaguni Stout</h3>
@@ -250,7 +250,7 @@ The following are descriptions for each of the beers in the quadrant.
         Shimaguni Stout: [0.35, 0.25]
     ```
 
-    Read more about [Shimaguni Stout](https://bairdbeer.com/beer/shimaguni-stout) on the Baird Brewing website.
+    Read more about [Shimaguni Stout](https://bairdbeer.com/products/shimaguni-stout) on the Baird Brewing website.
   </TabItem>
   <TabItem value="12" label="12">
     <h3>Kurofune Porter</h3>
@@ -269,6 +269,6 @@ The following are descriptions for each of the beers in the quadrant.
         Kurofune Porter: [0.45, 0.30]
     ```
 
-    Read more about [Kurofune Porter](https://bairdbeer.com/beer/kurofune-porter) on the Baird Brewing website.
+    Read more about [Kurofune Porter](https://bairdbeer.com/products/kurofune-porter) on the Baird Brewing website.
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Description

This PR fixes broken links to Baird beer product pages. The Baird website was recently updated, so these links need to be updated since server-side redirects weren't created.

## Related issues and/or PRs

N/A

## Changes made

- Changed links starting with `https://bairdbeer.com/beer/` to `https://bairdbeer.com/collections/`.
- Updated docs in OpenAI vector storage as well so that chatbot responses include the correct links.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
