### PR TITLE
Fix test deployment workflow to run properly in PRs

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,16 +4,18 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '!.github/**'
+    paths-ignore:
+      - '.github/workflows/auto-create-pr-*.yml'
+      - '.github/workflows/auto-label-pr-*.yml'
+      - '.github/FUNDING.yml'
+      - '.github/pull_request_template.md'
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
   workflow_dispatch:
-  # Only trigger, when the build workflow succeeded
-  workflow_run:
-    workflows: ["PR checklist checker"]
-    types:
-      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-deploy:


### PR DESCRIPTION
## Description

This PR fixes issue #102 where the test deployment workflow was not running properly in pull requests.

## Related issues and/or PRs

- **Issue**: #102

## Changes made

- **Removed  trigger**: The  trigger was causing the test deployment workflow to run on the main branch instead of the PR branch, and it wasn't showing up in the PR checks.

- **Added proper concurrency configuration**: Added a concurrency group specific to this workflow to prevent conflicts while allowing it to run alongside the PR checklist checker.

- **Updated path exclusions**: Changed from excluding all  files to more specific exclusions, allowing workflow changes to trigger tests when appropriate.

## Technical details

The root cause was the  trigger which:
1. Runs in the context of the target branch (main) instead of the PR branch
2. Doesn't appear in the PR checks interface
3. Doesn't have access to the PR context

By removing this trigger and relying on the standard  trigger with proper concurrency configuration, the workflow will now:
1. Run on the correct branch (PR branch)
2. Show up in the PR checks interface
3. Work alongside the PR checklist checker without conflicts

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.