### PR TITLE
Add EULA section for PokerOdds AI app

### DIFF
--- a/docs/pokerodds-ai/index.mdx
+++ b/docs/pokerodds-ai/index.mdx
@@ -237,9 +237,66 @@ We may update this Privacy Policy periodically. We will notify users of signific
 
 #### 10. Contact Information
 
-For questions about this Privacy Policy or our privacy practices, please contact us at:
+For questions about this Privacy Policy or our privacy practices, please contact the developer through the App Store or via the contact option in the App settings.
 
-📧 **Email:** [pokeroddsai-ios.reforest372@passfwd.com](mailto:pokeroddsai-ios.reforest372@passfwd.com)
+</details>
+
+### Terms of use (EULA)
+
+<details>
+  <summary>View PokerOdds AI Terms of Use (EULA)</summary>
+
+**Last updated:** July 23, 2025
+
+**1. Acceptance of terms**
+
+By downloading, installing, or using the PokerOdds AI app ("the App"), you agree to be bound by these Terms of Use. If you do not agree to these terms, please do not use the App.
+
+**2. App description**
+
+The App is a poker odds calculator tool designed to help users calculate probabilities and odds for Texas Hold'em poker games. It is intended for educational and entertainment purposes only.
+
+**3. Permitted use**
+
+You may use the App for personal, non-commercial purposes. You agree not to use the App for any unlawful purpose or in any way that could damage, disable, overburden, or impair the App.
+
+**4. Intellectual Property**
+
+All content, features, and functionality of the App are owned by the developer and are protected by copyright, trademark, and other intellectual property laws.
+
+**5. Disclaimer**
+
+The App is provided "as is" without any warranties. The developer does not guarantee the accuracy of calculations and is not responsible for any decisions made based on the App's output.
+
+**6. Limitation of liability**
+
+The developer shall not be liable for any direct, indirect, incidental, special, or consequential damages arising from the use of the App.
+
+**7. Privacy**
+
+The App does not collect, store, or transmit personal information. All calculations are performed locally on your device.
+
+**8. Purchases and refunds**
+
+**Credit Purchases:**
+
+All credit purchases are final and non-refundable. Credits purchased are added immediately to your account and can be used for AI-powered hand analysis.
+
+**Premium Subscriptions:**
+
+Premium subscriptions automatically renew unless auto-renew is turned off at least 24 hours before the end of the current period. Your account will be charged for renewal within 24 hours prior to the end of the current period. You can manage or cancel your subscription through your Apple ID account settings.
+
+**Refund Policy:**
+
+Refunds for subscriptions are subject to Apple's policies. To request a refund, contact Apple Support through your purchase history. Cancelling a subscription does not automatically generate a refund for the current period.
+
+**9. Changes to terms**
+
+These terms may be updated from time to time. Continued use of the App after changes constitutes acceptance of the new terms.
+
+**10. Contact information**
+
+For questions about these Terms of Use, please contact the developer through the App Store or via the contact option in the App settings.
 
 </details>
 
@@ -257,5 +314,5 @@ For questions about this Privacy Policy or our privacy practices, please contact
   lineHeight: '100px',
   height: '100px'
 }}>
-  🚀 Improve your poker game with the power of AI. Download PokerOdds AI!
+  🚀 Improve your poker knowledge with the power of AI. Download PokerOdds AI!
 </div>


### PR DESCRIPTION
## Description

This PR adds a detailed Terms of Use (EULA) for the PokerOdds AI app for iOS section.

- [ ] This PR includes a new feature.

## Related issues and/or PRs

N/A

## Changes made

* Added a comprehensive Terms of Use (EULA) section, outlining rules for app usage, intellectual property, disclaimers, privacy, and subscription policies. This includes details on credit purchases, premium subscriptions, and refund policies.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
